### PR TITLE
chore: Use interface instead of type

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -36,7 +36,7 @@ import type {
   XReadReply,
 } from "./stream.ts";
 
-export type RedisCommands = {
+export interface RedisCommands {
   // Connection
   auth(password: string): Promise<Status>;
   auth(username: string, password: string): Promise<Status>;
@@ -943,4 +943,4 @@ XRANGE somestream - +
   // Pipeline
   tx(): RedisPipeline;
   pipeline(): RedisPipeline;
-};
+}

--- a/connection.ts
+++ b/connection.ts
@@ -17,14 +17,14 @@ export interface Connection {
   forceRetry(): void;
 }
 
-export type RedisConnectionOptions = {
+export interface RedisConnectionOptions {
   tls?: boolean;
   db?: number;
   password?: string;
   name?: string;
   maxRetryCount?: number;
   retryInterval?: number;
-};
+}
 
 export class RedisConnection implements Connection {
   name: string | null = null;

--- a/pipeline.ts
+++ b/pipeline.ts
@@ -4,9 +4,9 @@ import { RawReplyOrError, RedisRawReply, sendCommands } from "./io.ts";
 import { Redis, RedisImpl } from "./redis.ts";
 import { Deferred, deferred } from "./vendor/https/deno.land/std/async/mod.ts";
 
-export type RedisPipeline = Redis & {
+export interface RedisPipeline extends Redis {
   flush(): Promise<RawReplyOrError[]>;
-};
+}
 
 export function createRedisPipeline(
   connection: Connection,

--- a/pubsub.ts
+++ b/pubsub.ts
@@ -2,7 +2,7 @@ import type { Connection } from "./connection.ts";
 import { InvalidStateError } from "./errors.ts";
 import { readArrayReply, sendCommand } from "./io.ts";
 
-export type RedisSubscription = {
+export interface RedisSubscription {
   readonly isClosed: boolean;
   receive(): AsyncIterableIterator<RedisPubSubMessage>;
   psubscribe(...patterns: string[]): Promise<void>;
@@ -10,13 +10,13 @@ export type RedisSubscription = {
   punsubscribe(...patterns: string[]): Promise<void>;
   unsubscribe(...channels: string[]): Promise<void>;
   close(): Promise<void>;
-};
+}
 
-export type RedisPubSubMessage = {
+export interface RedisPubSubMessage {
   pattern?: string;
   channel: string;
   message: string;
-};
+}
 
 class RedisSubscriptionImpl implements RedisSubscription {
   get isConnected(): boolean {

--- a/redis.ts
+++ b/redis.ts
@@ -46,13 +46,13 @@ import {
   XReadStreamRaw,
 } from "./stream.ts";
 
-export type Redis = RedisCommands & {
+export interface Redis extends RedisCommands {
   readonly connection: Connection;
   readonly executor: CommandExecutor;
   readonly isClosed: boolean;
   readonly isConnected: boolean;
   close(): void;
-};
+}
 
 export class RedisImpl implements Redis {
   readonly connection: Connection;
@@ -2082,7 +2082,7 @@ export class RedisImpl implements Redis {
   }
 }
 
-export type RedisConnectOptions = {
+export interface RedisConnectOptions {
   hostname: string;
   port?: number | string;
   tls?: boolean;
@@ -2091,7 +2091,7 @@ export type RedisConnectOptions = {
   name?: string;
   maxRetryCount?: number;
   retryInterval?: number;
-};
+}
 
 /**
  * Connect to Redis server


### PR DESCRIPTION
This PR is intended to make the output of `deno doc` move visible:

**Before this fix:**

```shell
$ deno doc mod.ts RedisCommands
Defined in file:///home/uki00a/ghq/github.com/uki00a/redis/command.ts:39:0 

type RedisCommands = { auth(password: string): Promise<Status>; auth(username: string, password: string): Promise<Status>; ... tx(): RedisPipeline; pipeline(): RedisPipeline; }
```

**After this fix:**

```shell
$ deno doc mod.ts RedisCommands
Defined in file:///home/uki00a/ghq/github.com/uki00a/redis/command.ts:39:0 

interface RedisCommands

  auth(password: string): Promise<Status>
  auth(username: string, password: string): Promise<Status>

    ...

  xack(key: string, group: string, ...xids: XIdInput[]): Promise<Integer>
    The XACK command removes one or multiple messages 
    from the pending entries list (PEL) of a stream
     consumer group. A message is pending, and as such
     stored inside the PEL, when it was delivered to 
    some consumer, normally as a side effect of calling
     XREADGROUP, or when a consumer took ownership of a
     message calling XCLAIM. The pending message was 
    delivered to some consumer but the server is yet not
     sure it was processed at least once. So new calls
     to XREADGROUP to grab the messages history for a 
    consumer (for instance using an XId of 0), will 
    return such message. Similarly the pending message 
    will be listed by the XPENDING command, that 
    inspects the PEL.
    
    Once a consumer successfully processes a message, 
    it should call XACK so that such message does not 
    get processed again, and as a side effect, the PEL
    entry about this message is also purged, releasing 
    memory from the Redis server.
    
    @param key the stream key
    @param group the group name
    @param xids the ids to acknowledge

  ...

  tx(): RedisPipeline
  pipeline(): RedisPipeline
```