### PR TITLE
Use a less collision-prone stream name in stream tests

### DIFF
--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -19,10 +19,9 @@ suite.afterAll(() => {
   client.close();
 });
 
+const rnum = () => Math.floor(Math.random() * 1000);
 const randomStream = () =>
-  `test-deno-${(new Date().getTime())}-${Math.floor(Math.random() * 1000)}${
-    Math.floor(Math.random() * 1000)
-  }${Math.floor(Math.random() * 1000)}`;
+  `test-deno-${(new Date().getTime())}-${rnum()}${rnum()}${rnum()}`;
 
 const cleanupStream = async (client: Redis, ...keys: string[]) => {
   await Promise.all(keys.map((key) => client.xtrim(key, { elements: 0 })));

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -20,7 +20,7 @@ suite.afterAll(() => {
 });
 
 const randomStream = () =>
-  `test-deno-${Math.floor(Math.random() * 1000)}${
+  `test-deno-${(new Date().getTime())}-${Math.floor(Math.random() * 1000)}${
     Math.floor(Math.random() * 1000)
   }${Math.floor(Math.random() * 1000)}`;
 

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -19,7 +19,7 @@ suite.afterAll(() => {
   client.close();
 });
 
-const randomStream = () => `test-deno-${Math.floor(Math.random() * 1000)}`;
+const randomStream = () => `test-deno-${Math.floor(Math.random() * 1000)}${Math.floor(Math.random() * 1000)}${Math.floor(Math.random() * 1000)}`;
 
 const cleanupStream = async (client: Redis, ...keys: string[]) => {
   await Promise.all(keys.map((key) => client.xtrim(key, { elements: 0 })));

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -484,7 +484,7 @@ suite.test("xclaim and xpending, all options", async () => {
 
     const firstPending = await client.xpending(key, group);
 
-    await delay(5);
+    await delay(50);
 
     assertEquals(firstPending.count, 2);
     assertNotEquals(firstPending.startId, firstPending.endId);
@@ -531,7 +531,7 @@ suite.test("xclaim and xpending, all options", async () => {
     });
 
     // take a short nap and increase the lastDeliveredMs
-    await delay(5);
+    await delay(50);
 
     // try another form of xpending: counts for all consumers (we have only one)
     const secondPending = await client.xpending_count(key, group, {
@@ -588,7 +588,7 @@ suite.test("xclaim and xpending, all options", async () => {
       consumer: "weird-interloper",
     });
 
-    await delay(5);
+    await delay(50);
 
     // try another form of xpending: counts
     // efficiently filtered down to a single consumer.
@@ -716,7 +716,7 @@ suite.test("xinfo", async () => {
     await client.xreadgroup([[key, ">"]], { group, consumer: "newbie" });
 
     // Increase the idle time by falling asleep
-    await delay(2);
+    await delay(10);
     const consumerInfos = await client.xinfo_consumers(key, group);
     assertEquals(consumerInfos.length, 2);
     const newConsumer = consumerInfos.find((c) => c.name === "newbie");

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -533,7 +533,7 @@ suite.test("xclaim and xpending, all options", async () => {
     });
 
     // take a short nap and increase the lastDeliveredMs
-    await delay(50);
+    await delay(5);
 
     // try another form of xpending: counts for all consumers (we have only one)
     const secondPending = await client.xpending_count(key, group, {
@@ -590,7 +590,7 @@ suite.test("xclaim and xpending, all options", async () => {
       consumer: "weird-interloper",
     });
 
-    await delay(50);
+    await delay(5);
 
     // try another form of xpending: counts
     // efficiently filtered down to a single consumer.
@@ -718,7 +718,7 @@ suite.test("xinfo", async () => {
     await client.xreadgroup([[key, ">"]], { group, consumer: "newbie" });
 
     // Increase the idle time by falling asleep
-    await delay(10);
+    await delay(2);
     const consumerInfos = await client.xinfo_consumers(key, group);
     assertEquals(consumerInfos.length, 2);
     const newConsumer = consumerInfos.find((c) => c.name === "newbie");

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -19,7 +19,10 @@ suite.afterAll(() => {
   client.close();
 });
 
-const randomStream = () => `test-deno-${Math.floor(Math.random() * 1000)}${Math.floor(Math.random() * 1000)}${Math.floor(Math.random() * 1000)}`;
+const randomStream = () =>
+  `test-deno-${Math.floor(Math.random() * 1000)}${
+    Math.floor(Math.random() * 1000)
+  }${Math.floor(Math.random() * 1000)}`;
 
 const cleanupStream = async (client: Redis, ...keys: string[]) => {
   await Promise.all(keys.map((key) => client.xtrim(key, { elements: 0 })));

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -486,7 +486,7 @@ suite.test("xclaim and xpending, all options", async () => {
 
     const firstPending = await client.xpending(key, group);
 
-    await delay(50);
+    await delay(5);
 
     assertEquals(firstPending.count, 2);
     assertNotEquals(firstPending.startId, firstPending.endId);


### PR DESCRIPTION
Trying to see how the Github Actions runs behave with these new `delay` values.

This will hopefully resolve #164 