### PR TITLE
feat: Implement CLIENT CACHING

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -49,6 +49,8 @@ export interface BitfieldWithOverflowOpts extends BitfieldOpts {
   overflow: "WRAP" | "SAT" | "FAIL";
 }
 
+export type ClientCachingMode = "YES" | "NO";
+
 export interface ClientTrackingOpts {
   mode: "ON" | "OFF";
   redirect?: number;
@@ -974,6 +976,12 @@ XRANGE somestream - +
   ): Promise<Integer>;
 
   // Client
+  /**
+   * This command controls the tracking of the keys in the next command executed by the connection.
+   * @see https://redis.io/commands/client-caching
+   */
+  clientCaching(mode: ClientCachingMode): Promise<Status>;
+
   /**
    * Returns the name of the current connection which can be set by `clientSetName`.
    * @see https://redis.io/commands/client-getname

--- a/mod.ts
+++ b/mod.ts
@@ -11,6 +11,7 @@ export type {
   ACLLogMode,
   BitfieldOpts,
   BitfieldWithOverflowOpts,
+  ClientCachingMode,
   ClientTrackingOpts,
   ClusterFailoverMode,
   ClusterResetMode,

--- a/redis.ts
+++ b/redis.ts
@@ -2,6 +2,7 @@ import type {
   ACLLogMode,
   BitfieldOpts,
   BitfieldWithOverflowOpts,
+  ClientCachingMode,
   ClientTrackingOpts,
   ClusterFailoverMode,
   ClusterResetMode,
@@ -313,6 +314,10 @@ export class RedisImpl implements Redis {
     return this.execArrayReply("BZPOPMAX", ...keys, timeout) as Promise<
       [BulkString, BulkString, BulkString] | []
     >;
+  }
+
+  clientCaching(mode: ClientCachingMode) {
+    return this.execStatusReply("CLIENT", "CACHING", mode);
   }
 
   clientGetName() {

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -1,4 +1,4 @@
-import { connect } from "../mod.ts";
+import { connect, Redis } from "../mod.ts";
 import {
   assertEquals,
   assertThrowsAsync,
@@ -7,7 +7,15 @@ import { newClient, startRedis, stopRedis, TestSuite } from "./test_util.ts";
 
 const suite = new TestSuite("connection");
 const server = await startRedis({ port: 7003 });
-const client = await newClient({ hostname: "127.0.0.1", port: 7003 });
+let client: Redis;
+
+suite.beforeEach(async () => {
+  client = await newClient({ hostname: "127.0.0.1", port: 7003 });
+});
+
+suite.afterEach(async () => {
+  client.close();
+});
 
 suite.afterAll(() => {
   stopRedis(server);
@@ -24,12 +32,11 @@ suite.test("ping", async () => {
 });
 
 suite.test("quit", async () => {
-  const tempClient = await connect({ hostname: "127.0.0.1", port: 7003 });
-  assertEquals(tempClient.isConnected, true);
-  assertEquals(tempClient.isClosed, false);
-  assertEquals(await tempClient.quit(), "OK");
-  assertEquals(tempClient.isConnected, false);
-  assertEquals(tempClient.isClosed, true);
+  assertEquals(client.isConnected, true);
+  assertEquals(client.isClosed, false);
+  assertEquals(await client.quit(), "OK");
+  assertEquals(client.isConnected, false);
+  assertEquals(client.isClosed, true);
 });
 
 suite.test("select", async () => {

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -13,7 +13,7 @@ suite.beforeEach(async () => {
   client = await newClient({ hostname: "127.0.0.1", port: 7003 });
 });
 
-suite.afterEach(async () => {
+suite.afterEach(() => {
   client.close();
 });
 

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -47,6 +47,26 @@ suite.test("swapdb", async () => {
   assertEquals(await client.swapdb(0, 1), "OK");
 });
 
+suite.test("client caching with opt in", async () => {
+  await client.clientTracking({ mode: "ON", optIn: true });
+  assertEquals(await client.clientCaching("YES"), "OK");
+});
+
+suite.test("client caching with opt out", async () => {
+  await client.clientTracking({ mode: "ON", optOut: true });
+  assertEquals(await client.clientCaching("NO"), "OK");
+});
+
+suite.test("client caching without opt in or opt out", async () => {
+  await assertThrowsAsync(
+    () => {
+      return client.clientCaching("YES");
+    },
+    Error,
+    "-ERR CLIENT CACHING can be called only when the client is in tracking mode with OPTIN or OPTOUT mode enabled",
+  );
+});
+
 suite.test("client id", async () => {
   const id = await client.clientID();
   assertEquals(typeof id, "number");

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -37,9 +37,12 @@ export class TestSuite {
         for (const f of this.beforeEachs) {
           await f();
         }
-        await test.func();
-        for (const f of this.afterEachs) {
-          await f();
+        try {
+          await test.func();
+        } finally {
+          for (const f of this.afterEachs) {
+            await f();
+          }
         }
       });
     }

--- a/tests/test_util.ts
+++ b/tests/test_util.ts
@@ -10,12 +10,17 @@ type TestServer = {
 export class TestSuite {
   private tests: { name: string; func: TestFunc }[] = [];
   private beforeEachs: TestFunc[] = [];
+  private afterEachs: TestFunc[] = [];
   private afterAlls: TestFunc[] = [];
 
   constructor(private prefix: string) {}
 
   beforeEach(func: TestFunc): void {
     this.beforeEachs.push(func);
+  }
+
+  afterEach(func: TestFunc): void {
+    this.afterEachs.push(func);
   }
 
   afterAll(func: TestFunc): void {
@@ -33,6 +38,9 @@ export class TestSuite {
           await f();
         }
         await test.func();
+        for (const f of this.afterEachs) {
+          await f();
+        }
       });
     }
     Deno.test({


### PR DESCRIPTION
Part of #174.

Hello 👋 . Two changes in this PR:
1. Implement `afterEach` in the test suite and added creating the client connection to a `beforeEach` in `connection_test` and `client.close()` to `afterEach`. I think some of the effects of client tracking were affecting some of the tests in client caching.
2. Implement client caching

If you like 1. would it be better to do it in a separate PR?


