### PR TITLE
fix: Make `subscribe` and `psubscribe` methods generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ await mainClient.clientTracking({
   mode: "ON",
   redirect: cacheClientID,
 });
-const sub = await cacheClient.subscribe("__redis__:invalidate");
+const sub = await cacheClient.subscribe<string[]>("__redis__:invalidate");
 
 (async () => {
   for await (const { channel, message } of sub.receive()) {

--- a/command.ts
+++ b/command.ts
@@ -478,12 +478,16 @@ export interface RedisCommands {
   pfmerge(destkey: string, ...sourcekeys: string[]): Promise<Status>;
 
   // PubSub
-  psubscribe(...patterns: string[]): Promise<RedisSubscription>;
+  psubscribe<TMessage extends string | string[] = string>(
+    ...patterns: string[]
+  ): Promise<RedisSubscription<TMessage>>;
   pubsubChannels(pattern?: string): Promise<BulkString[]>;
   pubsubNumsub(...channels: string[]): Promise<(BulkString | Integer)[]>;
   pubsubNumpat(): Promise<Integer>;
   publish(channel: string, message: string): Promise<Integer>;
-  subscribe(...channels: string[]): Promise<RedisSubscription>;
+  subscribe<TMessage extends string | string[] = string>(
+    ...channels: string[]
+  ): Promise<RedisSubscription<TMessage>>;
 
   // Set
   sadd(key: string, ...members: string[]): Promise<Integer>;

--- a/redis.ts
+++ b/redis.ts
@@ -1054,12 +1054,16 @@ export class RedisImpl implements Redis {
     return this.execIntegerReply("PUBLISH", channel, message);
   }
 
-  subscribe(...channels: string[]) {
-    return subscribe(this.connection, ...channels);
+  subscribe<TMessage extends string | string[] = string>(
+    ...channels: string[]
+  ) {
+    return subscribe<TMessage>(this.connection, ...channels);
   }
 
-  psubscribe(...patterns: string[]) {
-    return psubscribe(this.connection, ...patterns);
+  psubscribe<TMessage extends string | string[] = string>(
+    ...patterns: string[]
+  ) {
+    return psubscribe<TMessage>(this.connection, ...patterns);
   }
 
   pubsubChannels(pattern?: string) {


### PR DESCRIPTION
In some situations, a Pub/Sub subscriber receives messages in an array format. The current type definitions do not support those situations, so this commit changes `subscribe` and `psubscribe` to generic methods.