### PR TITLE
feat: Implement CLIENT UNPAUSE

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -1024,6 +1024,12 @@ XRANGE somestream - +
    */
   clientTracking(opts: ClientTrackingOpts): Promise<Status>;
 
+  /**
+   * Used to resume command processing for all clients that were paused by `clientPause`.
+   * @see https://redis.io/commands/client-unpause
+   */
+   clientUnpause(): Promise<Status>;
+
   // Cluster
   clusterAddSlots(...slots: number[]): Promise<Status>;
   clusterCountFailureReports(node_id: string): Promise<Integer>;

--- a/command.ts
+++ b/command.ts
@@ -1028,7 +1028,7 @@ XRANGE somestream - +
    * Used to resume command processing for all clients that were paused by `clientPause`.
    * @see https://redis.io/commands/client-unpause
    */
-   clientUnpause(): Promise<Status>;
+  clientUnpause(): Promise<Status>;
 
   // Cluster
   clusterAddSlots(...slots: number[]): Promise<Status>;

--- a/redis.ts
+++ b/redis.ts
@@ -370,6 +370,10 @@ export class RedisImpl implements Redis {
     return this.execStatusReply("CLIENT", "TRACKING", ...args);
   }
 
+  clientUnpause(): Promise<Status> {
+    return this.execStatusReply("CLIENT", "UNPAUSE");
+  }
+
   clusterAddSlots(...slots: number[]) {
     return this.execStatusReply("CLUSTER", "ADDSLOTS", ...slots);
   }

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -92,10 +92,11 @@ suite.test("client getredir with redirect", async () => {
   }
 });
 
-suite.test("client pause", async () => {
-  assertEquals(await client.clientPause(10), "OK");
-  assertEquals(await client.clientPause(10, "WRITE"), "OK");
-  assertEquals(await client.clientPause(10, "ALL"), "OK");
+suite.test("client pause & unpause", async () => {
+  assertEquals(await client.clientPause(5), "OK");
+  assertEquals(await client.clientPause(5, "ALL"), "OK");
+  assertEquals(await client.clientPause(5, "WRITE"), "OK");
+  assertEquals(await client.clientUnpause(), "OK");
 });
 
 suite.test("client tracking", async () => {


### PR DESCRIPTION
Part of #174. Sorry, a lot of these PRs recently, but it's quite fun 😄 Thanks for all the reviews until now @uki00a!

By the way the docs say
> Since Redis 6.2, the recommended mode for client pause is WRITE. This mode will stop all replication traffic, can be aborted with the CLIENT UNPAUSE command.

and as far as I can tell the unpause command only works on clients paused using WRITE mode. I wonder if it is worth adding some documentation?