### PR TITLE
BREAKING: Remove Redis.connection

### DIFF
--- a/pipeline.ts
+++ b/pipeline.ts
@@ -25,7 +25,7 @@ export function createRedisPipeline(
   function flush(): Promise<RedisReplyOrError[]> {
     return executor.flush();
   }
-  const client = new RedisImpl(connection, executor);
+  const client = new RedisImpl(executor);
   return Object.assign(client, { flush });
 }
 

--- a/redis.ts
+++ b/redis.ts
@@ -40,7 +40,7 @@ import type {
   ZScanOpts,
   ZUnionstoreOpts,
 } from "./command.ts";
-import { Connection, RedisConnection } from "./connection.ts";
+import { RedisConnection } from "./connection.ts";
 import type { RedisConnectionOptions } from "./connection.ts";
 import { CommandExecutor, MuxExecutor } from "./executor.ts";
 import { unwrapReply } from "./protocol/mod.ts";

--- a/redis.ts
+++ b/redis.ts
@@ -101,24 +101,22 @@ export interface Redis extends RedisCommands {
 }
 
 export class RedisImpl implements Redis {
-  readonly #connection: Connection;
   readonly executor: CommandExecutor;
 
   get isClosed() {
-    return this.#connection.isClosed;
+    return this.executor.connection.isClosed;
   }
 
   get isConnected() {
-    return this.#connection.isConnected;
+    return this.executor.connection.isConnected;
   }
 
-  constructor(connection: Connection, executor: CommandExecutor) {
-    this.#connection = connection;
+  constructor(executor: CommandExecutor) {
     this.executor = executor;
   }
 
   close(): void {
-    this.#connection.close();
+    this.executor.connection.close();
   }
 
   async execReply(command: string, ...args: RedisValue[]): Promise<Raw> {
@@ -1143,13 +1141,13 @@ export class RedisImpl implements Redis {
   subscribe<TMessage extends string | string[] = string>(
     ...channels: string[]
   ) {
-    return subscribe<TMessage>(this.#connection, ...channels);
+    return subscribe<TMessage>(this.executor.connection, ...channels);
   }
 
   psubscribe<TMessage extends string | string[] = string>(
     ...patterns: string[]
   ) {
-    return psubscribe<TMessage>(this.#connection, ...patterns);
+    return psubscribe<TMessage>(this.executor.connection, ...patterns);
   }
 
   pubsubChannels(pattern?: string) {
@@ -2244,11 +2242,11 @@ export class RedisImpl implements Redis {
   }
 
   tx() {
-    return createRedisPipeline(this.#connection, true);
+    return createRedisPipeline(this.executor.connection, true);
   }
 
   pipeline() {
-    return createRedisPipeline(this.#connection);
+    return createRedisPipeline(this.executor.connection);
   }
 }
 
@@ -2269,7 +2267,7 @@ export async function connect(options: RedisConnectOptions): Promise<Redis> {
   const connection = new RedisConnection(hostname, port, opts);
   await connection.connect();
   const executor = new MuxExecutor(connection);
-  return new RedisImpl(connection, executor);
+  return new RedisImpl(executor);
 }
 
 /**

--- a/redis.ts
+++ b/redis.ts
@@ -94,7 +94,6 @@ import {
 } from "./stream.ts";
 
 export interface Redis extends RedisCommands {
-  readonly connection: Connection;
   readonly executor: CommandExecutor;
   readonly isClosed: boolean;
   readonly isConnected: boolean;
@@ -102,24 +101,24 @@ export interface Redis extends RedisCommands {
 }
 
 export class RedisImpl implements Redis {
-  readonly connection: Connection;
+  readonly #connection: Connection;
   readonly executor: CommandExecutor;
 
   get isClosed() {
-    return this.connection.isClosed;
+    return this.#connection.isClosed;
   }
 
   get isConnected() {
-    return this.connection.isConnected;
+    return this.#connection.isConnected;
   }
 
   constructor(connection: Connection, executor: CommandExecutor) {
-    this.connection = connection;
+    this.#connection = connection;
     this.executor = executor;
   }
 
   close(): void {
-    this.connection.close();
+    this.#connection.close();
   }
 
   async execReply(command: string, ...args: RedisValue[]): Promise<Raw> {
@@ -1144,13 +1143,13 @@ export class RedisImpl implements Redis {
   subscribe<TMessage extends string | string[] = string>(
     ...channels: string[]
   ) {
-    return subscribe<TMessage>(this.connection, ...channels);
+    return subscribe<TMessage>(this.#connection, ...channels);
   }
 
   psubscribe<TMessage extends string | string[] = string>(
     ...patterns: string[]
   ) {
-    return psubscribe<TMessage>(this.connection, ...patterns);
+    return psubscribe<TMessage>(this.#connection, ...patterns);
   }
 
   pubsubChannels(pattern?: string) {
@@ -2245,11 +2244,11 @@ export class RedisImpl implements Redis {
   }
 
   tx() {
-    return createRedisPipeline(this.connection, true);
+    return createRedisPipeline(this.#connection, true);
   }
 
   pipeline() {
-    return createRedisPipeline(this.connection);
+    return createRedisPipeline(this.#connection);
   }
 }
 


### PR DESCRIPTION
I think `Redis.connection` should be used only internally. In this PR, it is removed in preparation for the v1 release.