### PR TITLE
chore: Replace assertThrowsAsync with assertRejects

### DIFF
--- a/tests/client_test.ts
+++ b/tests/client_test.ts
@@ -3,7 +3,7 @@ import { delay } from "../vendor/https/deno.land/std/async/delay.ts";
 import {
   assert,
   assertEquals,
-  assertThrowsAsync,
+  assertRejects,
 } from "../vendor/https/deno.land/std/testing/asserts.ts";
 import {
   newClient,
@@ -42,7 +42,7 @@ suite.test("client caching with opt out", async () => {
 });
 
 suite.test("client caching without opt in or opt out", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     () => {
       return client.clientCaching("YES");
     },
@@ -130,7 +130,7 @@ suite.test("client list", async () => {
   list = await client.clientList({ ids: [id] });
   assert(list!.includes(`id=${id}`));
 
-  await assertThrowsAsync(
+  await assertRejects(
     () => {
       return client.clientList({ type: "MASTER", ids: [id] });
     },
@@ -157,7 +157,7 @@ suite.test("client tracking", async () => {
     }),
     "OK",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () => {
       return client.clientTracking({ mode: "ON", bcast: true, optIn: true });
     },
@@ -194,7 +194,7 @@ suite.test("client unblock with error", async () => {
   const tempClient = await newClient({ hostname: "127.0.0.1", port });
   try {
     const id = await tempClient.clientID();
-    assertThrowsAsync(
+    await assertRejects(
       () => tempClient.brpop(0, "key1"),
       Error,
       "-UNBLOCKED",

--- a/tests/client_test.ts
+++ b/tests/client_test.ts
@@ -194,13 +194,14 @@ suite.test("client unblock with error", async () => {
   const tempClient = await newClient({ hostname: "127.0.0.1", port });
   try {
     const id = await tempClient.clientID();
-    await assertRejects(
+    const promise = assertRejects(
       () => tempClient.brpop(0, "key1"),
       Error,
       "-UNBLOCKED",
     );
     await delay(5); // Give some leeway for brpop to reach redis.
     assertEquals(await client.clientUnblock(id, "ERROR"), 1);
+    await promise;
   } finally {
     tempClient.close();
   }

--- a/tests/cluster/test.ts
+++ b/tests/cluster/test.ts
@@ -5,7 +5,7 @@ import {
   assert,
   assertArrayIncludes,
   assertEquals,
-  assertThrowsAsync,
+  assertRejects,
 } from "../../vendor/https/deno.land/std/testing/asserts.ts";
 import sample from "../../vendor/https/cdn.skypack.dev/lodash-es/sample.js";
 import calculateSlot from "../../vendor/https/cdn.skypack.dev/cluster-key-slot/lib/index.js";
@@ -40,7 +40,7 @@ suite.test("del multiple keys in the same hash slot", async () => {
 suite.test("del multiple keys in different hash slots", async () => {
   await client.set("foo", "a");
   await client.set("bar", "b");
-  await assertThrowsAsync(
+  await assertRejects(
     async () => {
       await client.del("foo", "bar");
     },
@@ -186,7 +186,7 @@ suite.test("properly handle too many redirections", async () => {
     },
   });
   try {
-    await assertThrowsAsync(
+    await assertRejects(
       () => client.get("foo"),
       Error,
       "Too many Cluster redirections?",

--- a/tests/general_test.ts
+++ b/tests/general_test.ts
@@ -1,7 +1,7 @@
 import { ErrorReplyError, parseURL } from "../mod.ts";
 import {
   assertEquals,
-  assertThrowsAsync,
+  assertRejects,
 } from "../vendor/https/deno.land/std/testing/asserts.ts";
 import {
   newClient,
@@ -52,7 +52,7 @@ suite.test("db0", async () => {
 });
 
 suite.test("connect with wrong password", async () => {
-  await assertThrowsAsync(async () => {
+  await assertRejects(async () => {
     await newClient({
       hostname: "127.0.0.1",
       port,
@@ -63,7 +63,7 @@ suite.test("connect with wrong password", async () => {
 
 suite.test("connect with empty password", async () => {
   // In Redis, authentication with an empty password will always fail.
-  await assertThrowsAsync(async () => {
+  await assertRejects(async () => {
     await newClient({
       hostname: "127.0.0.1",
       port,
@@ -87,7 +87,7 @@ suite.test("exists", async () => {
 
 [Infinity, NaN, "", "port"].forEach((v) => {
   suite.test(`invalid port: ${v}`, async () => {
-    await assertThrowsAsync(
+    await assertRejects(
       async () => {
         await newClient({ hostname: "127.0.0.1", port: v });
       },

--- a/tests/pubsub_test.ts
+++ b/tests/pubsub_test.ts
@@ -2,7 +2,7 @@ import { delay } from "../vendor/https/deno.land/std/async/delay.ts";
 import {
   assert,
   assertEquals,
-  assertThrowsAsync,
+  assertRejects,
 } from "../vendor/https/deno.land/std/testing/asserts.ts";
 import {
   newClient,
@@ -48,7 +48,7 @@ suite.test("testSubscribe2", async () => {
   assertEquals(sub.isClosed, true);
   assertEquals(client.isClosed, true);
   pub.close();
-  await assertThrowsAsync(async () => {
+  await assertRejects(async () => {
     await client.get("aaa");
   }, Deno.errors.BadResource);
 });

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -5,7 +5,7 @@ import {
   assert,
   assertEquals,
   assertNotEquals,
-  assertThrowsAsync,
+  assertRejects,
 } from "../vendor/https/deno.land/std/testing/asserts.ts";
 import {
   newClient,
@@ -196,7 +196,7 @@ suite.test("xgroup create and destroy", async () => {
 
   const created = await client.xgroupCreate(key, groupName, "$", true);
   assertEquals(created, "OK");
-  await assertThrowsAsync(
+  await assertRejects(
     async () => {
       await client.xgroupCreate(key, groupName, 0, true);
     },


### PR DESCRIPTION
`assertThrowsAsync` has been deprecated in deno_std v0.104.0.