### PR TITLE
BREAKING: [WIP] Introduce `Client` interface

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -21,7 +21,7 @@ export interface Client {
     ...args: RedisValue[]
   ): Promise<RedisReply>;
 
-  execBatch(
+  batch(
     commands: Array<RedisCommand>,
   ): Promise<RedisReplyOrError[]>;
 
@@ -199,7 +199,7 @@ class BasicClient implements Client {
     return d;
   }
 
-  execBatch(
+  batch(
     commands: Array<RedisCommand>,
   ): Promise<RedisReplyOrError[]> {
     return sendCommands(this.#writer, this.#reader, commands);

--- a/client.ts
+++ b/client.ts
@@ -1,0 +1,268 @@
+import { RedisCommand, RedisReply, RedisReplyOrError, RedisValue, readReply, sendCommand, sendCommands } from "./protocol/mod.ts";
+import { EOFError } from "./errors.ts";
+import { BufReader, BufWriter } from "./vendor/https/deno.land/std/io/bufio.ts";
+import {
+  Deferred,
+  deferred,
+} from "./vendor/https/deno.land/std/async/deferred.ts";
+
+const kDefaultRetryInterval = 1200;
+const kDefaultMaxRetryCount = 0;
+
+/**
+ * Low level Redis client
+ */
+export interface Client {
+  /**
+   * Execute `command` with the given `args`.
+   */
+  exec(
+    command: string,
+    ...args: RedisValue[]
+  ): Promise<RedisReply>;
+
+  execBatch(
+    commands: Array<RedisCommand>,
+  ): Promise<RedisReplyOrError[]>;
+
+  /**
+   * This method is intended for use in Pub/Sub etc.
+   */
+  readNextReply(): Promise<RedisReply>;
+
+  /**
+   * Establish a connection to the Redis Server.
+   */
+  connect(): Promise<void>;
+
+  close(): void;
+  reconnect(): Promise<void>;
+
+  /**
+   * @private
+   */
+  _forceRetry(): void;
+
+  isClosed: boolean;
+  isConnected: boolean;
+  isRetriable: boolean;
+}
+
+export interface RedisConnectionOptions {
+  tls?: boolean;
+  db?: number;
+  password?: string;
+  maxRetryCount?: number;
+  retryInterval?: number;
+}
+
+export function create(hostname: string, port: number | string, options: RedisConnectionOptions): Client {
+  return new BasicClient(hostname, port, options ?? {});
+}
+
+export async function connect(
+  hostname: string,
+  port: number | string,
+  options: RedisConnectionOptions,
+): Promise<Client> {
+  const client = create(hostname, port, options);
+  await client.connect();
+  return client;
+}
+
+class BasicClient implements Client {
+  readonly #options: RedisConnectionOptions;
+  readonly #hostname: string;
+  readonly #port: number | string;
+  #writer!: BufWriter;
+  #reader!: BufReader;
+  #closer!: Deno.Closer;
+
+  #isConnected?: boolean;
+  #isClosed?: boolean;
+  #maxRetryCount: number;
+  #retryInterval: number;
+
+
+  #queue: {
+    command: string;
+    args: RedisValue[];
+    d: Deferred<RedisReply>;
+  }[] = [];
+
+  constructor(
+    hostname: string,
+    port: number | string,
+    options: RedisConnectionOptions) {
+    this.#options = options;
+    this.#hostname = hostname;
+    this.#port = port;
+    this.#maxRetryCount = options.maxRetryCount ?? kDefaultMaxRetryCount;
+    this.#retryInterval = options.retryInterval ?? kDefaultRetryInterval;
+  }
+
+  get isClosed(): boolean {
+    return this.#isClosed ?? true;
+  }
+
+  get isConnected(): boolean {
+    return this.#isConnected ?? false;
+  }
+
+  get isRetriable(): boolean {
+    return this.#maxRetryCount > 0;
+  }
+
+  async connect() {
+    const options = this.#options;
+    const dialOpts: Deno.ConnectOptions = {
+      hostname: this.#hostname,
+      port: parsePortLike(this.#port),
+    };
+    const conn: Deno.Conn = options?.tls
+      ? await Deno.connectTls(dialOpts)
+      : await Deno.connect(dialOpts);
+
+    this.#closer = conn;
+    this.#reader = new BufReader(conn);
+    this.#writer = new BufWriter(conn);
+    this.#isClosed = false;
+    this.#isConnected = true;
+
+    try {
+      if (options?.password != null) {
+        await this.#authenticate(options.password);
+      }
+      if (options?.db) {
+        await this.#selectDb(options.db);
+      }
+    } catch (error) {
+      this.close();
+      throw error;
+    }
+  }
+
+  readNextReply(): Promise<RedisReply> {
+    return readReply(this.#reader);
+  }
+
+  close() {
+    this.#isClosed = true;
+    this.#isConnected = false;
+    try {
+      this.#closer.close();
+    } catch (error) {
+      if (!(error instanceof Deno.errors.BadResource)) throw error;
+    }
+  }
+
+  async reconnect(): Promise<void> {
+    if (!this.#reader.peek(1)) {
+      throw new Error("Client is closed.");
+    }
+    try {
+      await sendCommand(this.#writer, this.#reader, "PING");
+      this.#isConnected = true;
+    } catch (_error) { // TODO: Maybe we should log this error.
+      this.#isConnected = false;
+      let retryCount = 0;
+      return new Promise((resolve, reject) => {
+        const _interval = setInterval(async () => {
+          if (retryCount > this.#maxRetryCount) {
+            this.close();
+            clearInterval(_interval);
+            reject(new Error("Could not reconnect"));
+          }
+          try {
+            this.close();
+            await this.connect();
+            await sendCommand(this.#writer, this.#reader, "PING");
+            this.#isConnected = true;
+            clearInterval(_interval);
+            resolve();
+          } catch (_err) {
+            // retrying
+          } finally {
+            retryCount++;
+          }
+        }, this.#retryInterval);
+      });
+    }
+  }
+
+  exec(command: string, ...args: RedisValue[]): Promise<RedisReply> {
+    const d = deferred<RedisReply>();
+    this.#queue.push({ command, args, d });
+    if (this.#queue.length === 1) {
+      this.#dequeue();
+    }
+    return d;
+  }
+
+  execBatch(
+    commands: Array<RedisCommand>,
+  ): Promise<RedisReplyOrError[]> {
+    return sendCommands(this.#writer, this.#reader, commands);
+  }
+
+  #dequeue(): void {
+    const [e] = this.#queue;
+    if (!e) return;
+    sendCommand(
+      this.#writer,
+      this.#reader,
+      e.command,
+      ...e.args,
+    )
+      .then(e.d.resolve)
+      .catch(async (error) => {
+        if (
+          this.isRetriable &&
+          // Error `BadResource` is thrown when an attempt is made to write to a closed connection,
+          //  Make sure that the connection wasn't explicitly closed by the user before trying to reconnect.
+          ((error instanceof Deno.errors.BadResource &&
+            !this.#isClosed) ||
+            error instanceof Deno.errors.BrokenPipe ||
+            error instanceof Deno.errors.ConnectionAborted ||
+            error instanceof Deno.errors.ConnectionRefused ||
+            error instanceof Deno.errors.ConnectionReset ||
+            error instanceof EOFError)
+        ) {
+          await this.reconnect();
+        } else e.d.reject(error);
+      })
+      .finally(() => {
+        this.#queue.shift();
+        this.#dequeue();
+      });
+  }
+
+  #authenticate(password: string): Promise<RedisReply> {
+    return sendCommand(this.#writer, this.#reader, "AUTH", password);
+  }
+
+  #selectDb(
+    db: number,
+  ): Promise<RedisReply> {
+    return sendCommand(this.#writer, this.#reader, "SELECT", db);
+  }
+
+  _forceRetry(): void {
+    this.#maxRetryCount = 10; // TODO Adjust this.
+  }
+}
+
+function parsePortLike(port: string | number | undefined): number {
+  let parsedPort: number;
+  if (typeof port === "string") {
+    parsedPort = parseInt(port);
+  } else if (typeof port === "number") {
+    parsedPort = port;
+  } else {
+    parsedPort = 6379;
+  }
+  if (!Number.isSafeInteger(parsedPort)) {
+    throw new Error("Port is invalid");
+  }
+  return parsedPort;
+}

--- a/pipeline.ts
+++ b/pipeline.ts
@@ -1,11 +1,10 @@
-import type { Connection } from "./connection.ts";
-import { CommandExecutor } from "./executor.ts";
+import type { Client } from "./client.ts";
 import {
   createSimpleStringReply,
+  RedisCommand,
   RedisReply,
   RedisReplyOrError,
   RedisValue,
-  sendCommands,
 } from "./protocol/mod.ts";
 import { create, Redis } from "./redis.ts";
 import {
@@ -18,66 +17,100 @@ export interface RedisPipeline extends Redis {
 }
 
 export function createRedisPipeline(
-  connection: Connection,
+  client: Client,
   tx = false,
 ): RedisPipeline {
-  const executor = new PipelineExecutor(connection, tx);
+  const pipelineClient = new PipelineClient(client, tx);
   function flush(): Promise<RedisReplyOrError[]> {
-    return executor.flush();
+    return pipelineClient.flush();
   }
-  const client = create(executor);
-  return Object.assign(client, { flush });
+  return Object.assign(create(pipelineClient), { flush });
 }
 
-export class PipelineExecutor implements CommandExecutor {
-  private commands: {
-    command: string;
-    args: RedisValue[];
-  }[] = [];
-  private queue: {
-    commands: {
-      command: string;
-      args: RedisValue[];
-    }[];
+export class PipelineClient implements Client {
+  #commands: RedisCommand[] = [];
+  #queue: {
+    commands: RedisCommand[];
     d: Deferred<RedisReplyOrError[]>;
   }[] = [];
 
+  #client: Client;
+  #tx: boolean;
+
+  get isClosed() {
+    return this.#client.isClosed;
+  }
+
+  get isConnected() {
+    return this.#client.isConnected;
+  }
+
+  get isRetriable() {
+    return this.#client.isRetriable;
+  }
+
   constructor(
-    readonly connection: Connection,
-    private tx: boolean,
+    client: Client,
+    tx: boolean,
   ) {
+    this.#client = client;
+    this.#tx = tx;
   }
 
   exec(
     command: string,
     ...args: RedisValue[]
   ): Promise<RedisReply> {
-    this.commands.push({ command, args });
+    this.#commands.push({ name: command, args });
     return Promise.resolve(createSimpleStringReply("OK"));
   }
 
+  execBatch(commands: RedisCommand[]) {
+    return this.#client.execBatch(commands);
+  }
+
+  readNextReply() {
+    return this.#client.readNextReply();
+  }
+
+  connect() {
+    return this.#client.connect();
+  }
+
+  close() {
+    return this.#client.close();
+  }
+
+  reconnect() {
+    return this.#client.reconnect();
+  }
+
+  _forceRetry() {
+    return this.#client._forceRetry();
+  }
+
   flush(): Promise<RedisReplyOrError[]> {
-    if (this.tx) {
-      this.commands.unshift({ command: "MULTI", args: [] });
-      this.commands.push({ command: "EXEC", args: [] });
+    if (this.#tx) {
+      this.#commands.unshift({ command: "MULTI", args: [] });
+      this.#commands.push({ command: "EXEC", args: [] });
     }
     const d = deferred<RedisReplyOrError[]>();
-    this.queue.push({ commands: [...this.commands], d });
-    if (this.queue.length === 1) {
+    this.#queue.push({ commands: [...this.#commands], d });
+    if (this.#queue.length === 1) {
       this.dequeue();
     }
-    this.commands = [];
+    this.#commands = [];
     return d;
   }
 
   private dequeue(): void {
-    const [e] = this.queue;
+    const [e] = this.#queue;
     if (!e) return;
-    sendCommands(this.connection.writer, this.connection.reader, e.commands)
+    this.#client.execBatch(e.commands)
       .then(e.d.resolve)
       .catch(e.d.reject)
       .finally(() => {
-        this.queue.shift();
+        this.#queue.shift();
         this.dequeue();
       });
   }

--- a/pipeline.ts
+++ b/pipeline.ts
@@ -65,8 +65,8 @@ export class PipelineClient implements Client {
     return Promise.resolve(createSimpleStringReply("OK"));
   }
 
-  execBatch(commands: RedisCommand[]) {
-    return this.#client.execBatch(commands);
+  batch(commands: RedisCommand[]) {
+    return this.#client.batch(commands);
   }
 
   readNextReply() {
@@ -106,7 +106,7 @@ export class PipelineClient implements Client {
   private dequeue(): void {
     const [e] = this.#queue;
     if (!e) return;
-    this.#client.execBatch(e.commands)
+    this.#client.batch(e.commands)
       .then(e.d.resolve)
       .catch(e.d.reject)
       .finally(() => {

--- a/protocol/command.ts
+++ b/protocol/command.ts
@@ -47,16 +47,18 @@ export async function sendCommand(
   return readReply(reader);
 }
 
+export interface RedisCommand {
+  name: string;
+  args: RedisValue[];
+}
+
 export async function sendCommands(
   writer: BufWriter,
   reader: BufReader,
-  commands: {
-    command: string;
-    args: RedisValue[];
-  }[],
+  commands: Command[],
 ): Promise<RedisReplyOrError[]> {
-  for (const { command, args } of commands) {
-    await writeRequest(writer, command, args);
+  for (const { name, args } of commands) {
+    await writeRequest(writer, name, args);
   }
   await writer.flush();
   const ret: RedisReplyOrError[] = [];

--- a/protocol/mod.ts
+++ b/protocol/mod.ts
@@ -25,4 +25,4 @@ export {
   unwrapReply,
 } from "./reply.ts";
 
-export { sendCommand, sendCommands } from "./command.ts";
+export { RedisCommand, sendCommand, sendCommands } from "./command.ts";

--- a/redis.ts
+++ b/redis.ts
@@ -40,10 +40,8 @@ import type {
   ZScanOpts,
   ZUnionstoreOpts,
 } from "./command.ts";
-import { RedisConnection } from "./connection.ts";
-import type { Connection } from "./connection.ts";
 import type { RedisConnectionOptions } from "./connection.ts";
-import { CommandExecutor, MuxExecutor } from "./executor.ts";
+import { connect as connectClient, create as createClient, Client } from "./client.ts";
 import { unwrapReply } from "./protocol/mod.ts";
 import type {
   Binary,
@@ -94,34 +92,36 @@ import {
   XReadStreamRaw,
 } from "./stream.ts";
 
+const kDefaultPort = 6379;
+
 export interface Redis extends RedisCommands {
-  readonly executor: CommandExecutor;
+  readonly client: Client;
   readonly isClosed: boolean;
   readonly isConnected: boolean;
   close(): void;
 }
 
 class RedisImpl implements Redis {
-  readonly executor: CommandExecutor;
+  readonly client: Client;
 
   get isClosed() {
-    return this.executor.connection.isClosed;
+    return this.client.isClosed;
   }
 
   get isConnected() {
-    return this.executor.connection.isConnected;
+    return this.client.isConnected;
   }
 
-  constructor(executor: CommandExecutor) {
-    this.executor = executor;
+  constructor(client: Client) {
+    this.client = client;
   }
 
   close(): void {
-    this.executor.connection.close();
+    this.client.close();
   }
 
   async execReply(command: string, ...args: RedisValue[]): Promise<Raw> {
-    const reply = await this.executor.exec(
+    const reply = await this.client.exec(
       command,
       ...args,
     );
@@ -132,7 +132,7 @@ class RedisImpl implements Redis {
     command: string,
     ...args: RedisValue[]
   ): Promise<SimpleString> {
-    const reply = await this.executor.exec(command, ...args);
+    const reply = await this.client.exec(command, ...args);
     return reply.value() as SimpleString;
   }
 
@@ -140,7 +140,7 @@ class RedisImpl implements Redis {
     command: string,
     ...args: RedisValue[]
   ): Promise<Integer> {
-    const reply = await this.executor.exec(command, ...args);
+    const reply = await this.client.exec(command, ...args);
     return reply.value() as Integer;
   }
 
@@ -148,7 +148,7 @@ class RedisImpl implements Redis {
     command: string,
     ...args: RedisValue[]
   ): Promise<Binary | BulkNil> {
-    const reply = await this.executor.exec(command, ...args) as BulkReply;
+    const reply = await this.client.exec(command, ...args) as BulkReply;
     return reply.buffer();
   }
 
@@ -156,7 +156,7 @@ class RedisImpl implements Redis {
     command: string,
     ...args: RedisValue[]
   ): Promise<T> {
-    const reply = await this.executor.exec(command, ...args);
+    const reply = await this.client.exec(command, ...args);
     return reply.value() as T;
   }
 
@@ -164,7 +164,7 @@ class RedisImpl implements Redis {
     command: string,
     ...args: RedisValue[]
   ): Promise<T[]> {
-    const reply = await this.executor.exec(command, ...args);
+    const reply = await this.client.exec(command, ...args);
     return reply.value() as T[];
   }
 
@@ -172,7 +172,7 @@ class RedisImpl implements Redis {
     command: string,
     ...args: RedisValue[]
   ): Promise<Integer | BulkNil> {
-    const reply = await this.executor.exec(command, ...args);
+    const reply = await this.client.exec(command, ...args);
     return reply.value() as Integer | BulkNil;
   }
 
@@ -180,7 +180,7 @@ class RedisImpl implements Redis {
     command: string,
     ...args: RedisValue[]
   ): Promise<SimpleString | BulkNil> {
-    const reply = await this.executor.exec(command, ...args);
+    const reply = await this.client.exec(command, ...args);
     return reply.value() as SimpleString | BulkNil;
   }
 
@@ -1146,13 +1146,13 @@ class RedisImpl implements Redis {
   subscribe<TMessage extends string | string[] = string>(
     ...channels: string[]
   ) {
-    return subscribe<TMessage>(this.executor.connection, ...channels);
+    return subscribe<TMessage>(this.client, ...channels);
   }
 
   psubscribe<TMessage extends string | string[] = string>(
     ...patterns: string[]
   ) {
-    return psubscribe<TMessage>(this.executor.connection, ...patterns);
+    return psubscribe<TMessage>(this.client, ...patterns);
   }
 
   pubsubChannels(pattern?: string) {
@@ -2271,10 +2271,9 @@ export interface RedisConnectOptions extends RedisConnectionOptions {
  * ```
  */
 export async function connect(options: RedisConnectOptions): Promise<Redis> {
-  const connection = createRedisConnection(options);
-  await connection.connect();
-  const executor = new MuxExecutor(connection);
-  return create(executor);
+  const { hostname, port = kDefaultPort, ...opts } = options;
+  const client = await connectClient(hostname, port, opts);
+  return create(client);
 }
 
 /**
@@ -2290,16 +2289,16 @@ export async function connect(options: RedisConnectOptions): Promise<Redis> {
  * ```
  */
 export function createLazyClient(options: RedisConnectOptions): Redis {
-  const connection = createRedisConnection(options);
-  const executor = createLazyExecutor(connection);
-  return create(executor);
+  const { hostname, port = kDefaultPort, ...opts } = options;
+  const client = createClient(hostname, port, opts);
+  return create(client);
 }
 
 /**
- * Create a redis client from `CommandExecutor`
+ * Create a redis client from `Client`
  */
-export function create(executor: CommandExecutor): Redis {
-  return new RedisImpl(executor);
+export function create(client: Client): Redis {
+  return new RedisImpl(client);
 }
 
 /**
@@ -2328,7 +2327,7 @@ export function parseURL(url: string): RedisConnectOptions {
     : searchParams.get("db") ?? undefined;
   return {
     hostname: hostname !== "" ? hostname : "localhost",
-    port: port !== "" ? parseInt(port, 10) : 6379,
+    port: port !== "" ? parseInt(port, 10) : kDefaultPort,
     tls: protocol == "rediss:" ? true : searchParams.get("ssl") === "true",
     db: db ? parseInt(db, 10) : undefined,
     name: username !== "" ? username : undefined,
@@ -2338,23 +2337,3 @@ export function parseURL(url: string): RedisConnectOptions {
   };
 }
 
-function createRedisConnection(options: RedisConnectOptions): Connection {
-  const { hostname, port = 6379, ...opts } = options;
-  return new RedisConnection(hostname, port, opts);
-}
-
-function createLazyExecutor(connection: Connection): CommandExecutor {
-  let executor: CommandExecutor | null = null;
-  return {
-    get connection() {
-      return connection;
-    },
-    async exec(command, ...args) {
-      if (!executor) {
-        executor = new MuxExecutor(connection);
-        await connection.connect();
-      }
-      return executor.exec(command, ...args);
-    },
-  };
-}


### PR DESCRIPTION
This PR removes `RedisConnection` and `CommandExecutor`, and introduces a new interface called `Client` instead. `Client` is a low-level Redis client that mainly abstracts connection handling and command execution.

Closes #237