### PR TITLE
docs(cluster): improve clustering example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ const thx = msgFV["no"];
 **Cluster**
 
 First, if you need to set up nodes into a working redis cluster:
+
 ```ts
 import { connect } from "https://deno.land/x/redis/mod.ts";
 
@@ -79,7 +80,8 @@ await redis.clusterNodes();
 // ... 127.0.0.1:6380@16380 master - 0 1593978766503 1 connected
 ```
 
-To consume a redis cluster, you can use [experimental/cluster module](experimental/cluster/README.md).
+To consume a redis cluster, you can use
+[experimental/cluster module](experimental/cluster/README.md).
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -63,14 +63,39 @@ const thx = msgFV["no"];
 
 **Cluster**
 
+> This is an experimental feature and may be subject to breaking changes even after a
+major release see [here](experimental/README.md)
+
+First, if you need to set up nodes into a working redis cluster:
 ```ts
 import { connect } from "https://deno.land/x/redis/mod.ts";
 
-const redis = await connect({ hostname: "127.0.0.1" });
+const redis = await connect({ hostname: "127.0.0.1", port: 6379 });
+
+// connect each node to form a cluster (see https://redis.io/commands/cluster-meet)
 await redis.clusterMeet("127.0.0.1", 6380);
+...
+
+// List the nodes in the cluster
 await redis.clusterNodes();
 // ... 127.0.0.1:6379@16379 myself,master - 0 1593978765000 0 connected
 // ... 127.0.0.1:6380@16380 master - 0 1593978766503 1 connected
+```
+
+To consume a redis cluster:
+```ts
+import { connect } from "https://deno.land/x/redis/experimental/cluster/mod.ts";
+
+const redis = await connect({
+  nodes: [
+    {
+      hostname: "127.0.0.1",
+      port: 6379
+    }
+  ]
+})
+
+await redis.get(...)
 ```
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ const thx = msgFV["no"];
 
 **Cluster**
 
-> This is an experimental feature and may be subject to breaking changes even after a
-major release see [here](experimental/README.md)
-
 First, if you need to set up nodes into a working redis cluster:
 ```ts
 import { connect } from "https://deno.land/x/redis/mod.ts";
@@ -82,21 +79,7 @@ await redis.clusterNodes();
 // ... 127.0.0.1:6380@16380 master - 0 1593978766503 1 connected
 ```
 
-To consume a redis cluster:
-```ts
-import { connect } from "https://deno.land/x/redis/experimental/cluster/mod.ts";
-
-const redis = await connect({
-  nodes: [
-    {
-      hostname: "127.0.0.1",
-      port: 6379
-    }
-  ]
-})
-
-await redis.get(...)
-```
+To consume a redis cluster, you can use [experimental/cluster module](experimental/cluster/README.md).
 
 ## Advanced Usage
 


### PR DESCRIPTION
The documentation for Cluster support detailed setting up a Redis cluster, but not consuming one (which requires using the experimental cluster executor).

This PR adds documentation on how to consume a Redis Cluster to the README