### PR TITLE
BREAKING: Change `RedisSubscription#close()` to return `void`

### DIFF
--- a/pubsub.ts
+++ b/pubsub.ts
@@ -14,7 +14,7 @@ export interface RedisSubscription<
   subscribe(...channels: string[]): Promise<void>;
   punsubscribe(...patterns: string[]): Promise<void>;
   unsubscribe(...channels: string[]): Promise<void>;
-  close(): Promise<void>;
+  close(): void;
 }
 
 export interface RedisPubSubMessage<TMessage = DefaultMessageType> {
@@ -129,13 +129,8 @@ class RedisSubscriptionImpl<
     }
   }
 
-  async close() {
-    try {
-      await this.unsubscribe(...Object.keys(this.channels));
-      await this.punsubscribe(...Object.keys(this.patterns));
-    } finally {
-      this.executor.connection.close();
-    }
+  close() {
+    this.executor.connection.close();
   }
 }
 

--- a/tests/commands/pubsub.ts
+++ b/tests/commands/pubsub.ts
@@ -18,7 +18,7 @@ export function pubsubTests(
     const client = await newClient(opts);
     const sub = await client.subscribe("subsc");
     await sub.unsubscribe("subsc");
-    await sub.close();
+    sub.close();
     assertEquals(sub.isClosed, true);
     client.close();
   });
@@ -38,7 +38,7 @@ export function pubsubTests(
       channel: "subsc2",
       message: "wayway",
     });
-    await sub.close();
+    sub.close();
     assertEquals(sub.isClosed, true);
     assertEquals(client.isClosed, true);
     pub.close();
@@ -72,7 +72,7 @@ export function pubsubTests(
       channel: "psubs",
       message: "heyhey",
     });
-    await sub.close();
+    sub.close();
     pub.close();
     client.close();
   });
@@ -125,7 +125,7 @@ export function pubsubTests(
 
     // Cleanup
     clearInterval(interval);
-    await sub.close();
+    sub.close();
     pub.close();
     client.close();
     stopRedis(tempServer);


### PR DESCRIPTION
This change is intended to improve consistency with `Deno.Conn` and `Redis`