### PR TITLE
added username+password auth support

### DIFF
--- a/connection.ts
+++ b/connection.ts
@@ -110,10 +110,13 @@ export class RedisConnection implements Connection {
     };
   }
 
-  private async authenticate(username: string | undefined, password: string): Promise<void> {
+  private async authenticate(
+    username: string | undefined,
+    password: string,
+  ): Promise<void> {
     password && username
       ? await this.sendCommand("AUTH", username, password)
-      : await this.sendCommand("AUTH", password)
+      : await this.sendCommand("AUTH", password);
   }
 
   private async selectDb(

--- a/connection.ts
+++ b/connection.ts
@@ -24,6 +24,7 @@ export interface RedisConnectionOptions {
   tls?: boolean;
   db?: number;
   password?: string;
+  username?: string;
   name?: string;
   maxRetryCount?: number;
   // TODO: Provide more flexible retry strategy
@@ -95,7 +96,7 @@ export class RedisConnection implements Connection {
 
       try {
         if (options?.password != null) {
-          await this.authenticate(options.password);
+          await this.authenticate(options?.username, options?.password);
         }
         if (options?.db) {
           await this.selectDb(options.db);
@@ -109,8 +110,10 @@ export class RedisConnection implements Connection {
     };
   }
 
-  private async authenticate(password: string): Promise<void> {
-    await this.sendCommand("AUTH", password);
+  private async authenticate(username: string | undefined, password: string): Promise<void> {
+    password && username
+      ? await this.sendCommand("AUTH", username, password)
+      : await this.sendCommand("AUTH", password)
   }
 
   private async selectDb(


### PR DESCRIPTION
Fixes issue #300

You can now use redis client with cloud hosted redis (redis enterprise/cloud stack) or any other redis server that has user+password authentication.

PR is not breaking, but has changed RedisConnectionOptions to support an optional username: string property.

Tests not included since, only tests that make sense require a redis instances setting up with:
- password only (auth token only)
- username + password
- no auth

I did not see mock redis server for this in tests, and existing test for authentication is only checking if a parameter has been passed and is valid.  Which exception handling catches anyway.

ps. been a while since I did a PR.  (also note, I have this code in production, be nice to use official repo for this. )