### PR TITLE
feat: add zinter command

### DIFF
--- a/command.ts
+++ b/command.ts
@@ -165,6 +165,10 @@ export interface ZRangeOpts {
   withScore?: boolean;
 }
 
+export type ZInterOpts = {
+  withScore?: boolean;
+} & ZStoreOpts;
+
 export interface ZRangeByLexOpts {
   limit?: { offset: number; count: number };
 }
@@ -933,6 +937,8 @@ XRANGE somestream - +
     increment: number,
     member: RedisValue,
   ): Promise<BulkString>;
+  zinter(keys: string[], opts?: ZInterOpts): Promise<Raw[]>;
+  zinter(key_weights: [string, number][], opts?: ZInterOpts): Promise<Raw[]>;
   zinterstore(
     destination: string,
     keys: string[],

--- a/command.ts
+++ b/command.ts
@@ -939,6 +939,10 @@ XRANGE somestream - +
   ): Promise<BulkString>;
   zinter(keys: string[], opts?: ZInterOpts): Promise<Raw[]>;
   zinter(key_weights: [string, number][], opts?: ZInterOpts): Promise<Raw[]>;
+  zinter(
+    key_weights: Record<string, number>,
+    opts?: ZInterOpts
+  ): Promise<Raw[]>;
   zinterstore(
     destination: string,
     keys: string[],

--- a/mod.ts
+++ b/mod.ts
@@ -45,6 +45,7 @@ export type {
   StralgoOpts,
   StralgoTarget,
   ZAddOpts,
+  ZInterOpts,
   ZInterstoreOpts,
   ZRangeByLexOpts,
   ZRangeByScoreOpts,

--- a/redis.ts
+++ b/redis.ts
@@ -33,6 +33,7 @@ import type {
   StralgoOpts,
   StralgoTarget,
   ZAddOpts,
+  ZInterOpts,
   ZInterstoreOpts,
   ZRangeByLexOpts,
   ZRangeByScoreOpts,
@@ -2027,6 +2028,17 @@ class RedisImpl implements Redis {
 
   zincrby(key: string, increment: number, member: string) {
     return this.execBulkReply<BulkString>("ZINCRBY", key, increment, member);
+  }
+
+  zinter(
+    keys: string[] | [string, number][] | Record<string, number>,
+    opts?: ZInterOpts,
+  ) {
+    const args = this.pushZStoreArgs([], keys, opts);
+    if (opts?.withScore) {
+      args.push("WITHSCORES");
+    }
+    return this.execArrayReply("ZINTER", ...args);
   }
 
   zinterstore(

--- a/tests/commands/sorted_set.ts
+++ b/tests/commands/sorted_set.ts
@@ -122,6 +122,26 @@ export function zsetTests(
     assertEquals(await client.zinterstore("dest", ["key", "key2"]), 1);
   });
 
+  it("zinter", async () => {
+    await client.zadd("key", { "1": 1, "2": 2 });
+    await client.zadd("key2", { "1": 1, "3": 3 });
+    assertEquals(await client.zinter(["key", "key2"]), ["1"]);
+    assertEquals(await client.zinter([["key", 2], ["key2", 3]]), ["1"]);
+    assertEquals(
+      await client.zinter([
+        ["key", 2],
+        ["key2", 3], 
+      ], { aggregate: "MIN" }),
+      ["1"]
+    );
+    assertEquals(
+      await client.zinter(["key", "key2"], {
+        withScore: true,
+      }),
+      ["1", "2"]
+    );
+  });
+
   it("zlexcount", async () => {
     await client.zadd("key2", { "1": 1, "2": 2 });
     assertEquals(await client.zlexcount("key", "-", "(2"), 0);


### PR DESCRIPTION
Hi there,

This PR adds the [zinter](https://redis.io/commands/zinter/) command which was missing. I tried to follow the same patterns I saw used for the other commands. Fun fact I learned today - `sinter` also works with sorted sets, but there's not `WITHSCORES` options which is what I needed. 

Cheers