### PR TITLE
Expose connect method on Redis

### DIFF
--- a/redis.ts
+++ b/redis.ts
@@ -102,6 +102,7 @@ export interface Redis extends RedisCommands {
    * Low level interface for Redis server
    */
   sendCommand(command: string, ...args: RedisValue[]): Promise<RedisReply>;
+  connect(): Promise<void>;
   close(): void;
 }
 
@@ -122,6 +123,10 @@ class RedisImpl implements Redis {
 
   sendCommand(command: string, ...args: RedisValue[]) {
     return this.executor.exec(command, ...args);
+  }
+
+  connect(): Promise<void> {
+    return this.executor.connection.connect();
   }
 
   close(): void {


### PR DESCRIPTION
We are currently creating a lazy client and would like a way to force a connection during server initialization.

We can send a dummy request to do this, but since there's already a `close()` method, adding `connect()` and being explicit is a lot nicer.

Let me know if this is something you're interested in adding. Thank you!