### PR TITLE
fix multi-pattern sorts

### DIFF
--- a/redis.ts
+++ b/redis.ts
@@ -1422,7 +1422,7 @@ class RedisImpl implements Redis {
       args.push("LIMIT", opts.limit.offset, opts.limit.count);
     }
     if (opts?.patterns) {
-      args.push("GET", ...opts.patterns);
+      args.push(...opts.patterns.flatMap((pattern) => ["GET", pattern]));
     }
     if (opts?.order) {
       args.push(opts.order);


### PR DESCRIPTION
gm deno's,

i noticed that calling `sort` with multiple patterns caused `[uncaught application error]: Error - -ERR syntax error` and fixed it in this pr.

issue:
```typescript
{ // SortOpts
  by: `*->foo`,
  patterns: ["*->bar", "*->zed"],
}
```
yielded `GET *->bar *->zed` because:
```typescript
args.push("GET", ...opts.patterns)
```

solution:
```typescript
args.push(...opts.patterns.flatMap((pattern) => (["GET", pattern])))
```
to correctly yield `GET *->bar GET *->zed`