### PR TITLE
feat: responsibly add support for unstable unix sockets

### DIFF
--- a/connection.ts
+++ b/connection.ts
@@ -158,15 +158,18 @@ export class RedisConnection implements Connection {
 
   async #connect(retryCount: number) {
     try {
-      const dialOpts = this.port === "unix" 
-        ? { path: this.hostname, transport: "unix" }
-        : { hostname: this.hostname, port: parsePortLike(this.port),
-      };
-      const conn = this.options?.tls && !("path" in dialOpts)
+      const dialOpts = this.port === "unix"
+        ? {
+          path: this.hostname,
+          transport: "unix",
+        }
+        : {
+          hostname: this.hostname,
+          port: parsePortLike(this.port),
+        };
+      const conn: Deno.Conn = this.options?.tls && !("path" in dialOpts)
         ? await Deno.connectTls(dialOpts)
-        : !("path" in dialOpts)
-          ? await Deno.connect(dialOpts)
-          : await Deno.connect(dialOpts as any);
+        : await Deno.connect(dialOpts as any);
 
       this.closer = conn;
       this.reader = new BufReader(conn);

--- a/connection.ts
+++ b/connection.ts
@@ -158,15 +158,15 @@ export class RedisConnection implements Connection {
 
   async #connect(retryCount: number) {
     try {
-      const dialOpts: Deno.ConnectOptions|Deno.UnixConnectOptions = this.port === "unix" 
+      const dialOpts = this.port === "unix" 
         ? { path: this.hostname, transport: "unix" }
         : { hostname: this.hostname, port: parsePortLike(this.port),
       };
       const conn = this.options?.tls && !("path" in dialOpts)
         ? await Deno.connectTls(dialOpts)
-        : !("path" in dialOpts) // function overloading -- just say no
+        : !("path" in dialOpts)
           ? await Deno.connect(dialOpts)
-          : await Deno.connect(dialOpts);
+          : await Deno.connect(dialOpts as any);
 
       this.closer = conn;
       this.reader = new BufReader(conn);

--- a/deno.json
+++ b/deno.json
@@ -17,5 +17,10 @@
     "bench:deno-redis": "DENO_NO_PACKAGE_JSON=1 deno run --unstable --allow-net=127.0.0.1:6379 --allow-read --allow-env --allow-write=tmp --import-map=benchmark/import_map.json benchmark/deno-redis.ts",
     "bench:ioredis": "node benchmark/ioredis.js"
   },
+  "compilerOptions": {
+    "lib": [
+      "deno.window"
+    ]
+  },
   "lock": false
 }

--- a/redis.ts
+++ b/redis.ts
@@ -2359,9 +2359,16 @@ class RedisImpl implements Redis {
   }
 }
 
-export interface RedisConnectOptions extends RedisConnectionOptions {
+export type RedisConnectOptions = RedisConnectOptionsTCP | RedisConnectOptionsUnix;
+
+export interface RedisConnectOptionsTCP extends RedisConnectionOptions {
   hostname: string;
   port?: number | string;
+}
+
+export interface RedisConnectOptionsUnix extends RedisConnectionOptions {
+  path: string;
+  transport: "unix";
 }
 
 /**
@@ -2443,6 +2450,10 @@ export function parseURL(url: string): RedisConnectOptions {
 }
 
 function createRedisConnection(options: RedisConnectOptions): Connection {
+  if ("transport" in options) {
+    const { path, transport, ...opts } = options;
+    return new RedisConnection(path, transport, opts);
+  }
   const { hostname, port = 6379, ...opts } = options;
   return new RedisConnection(hostname, port, opts);
 }


### PR DESCRIPTION
This PR adds support for connecting to Redis through Deno's unstable unix sockets without exposing this fact to callers who do not have `lib.deno.unstable` in scope. 

Specifically, calls to `connect` with [`UnixConnectOptions`](https://deno.land/api@v1.36.1?s=Deno.UnixConnectOptions&unstable=)-like properties will not pass type check, and intellisense will not suggest them unless `lib.deno.unstable` is in scope. 

Screenshots:
With unstable types imported:
<img width="688" alt="Screenshot 2023-08-18 at 10 40 48" src="https://github.com/denodrivers/redis/assets/108846768/4f3e61fb-151a-4971-8f2a-b6b0c847417a">

Without unstable types:
<img width="688" alt="Screenshot 2023-08-18 at 10 40 59" src="https://github.com/denodrivers/redis/assets/108846768/af998d96-ed65-4891-8849-d159154f7755">

I think this is a responsible way of using unstable APIs in library code that doesn't permit or advertise it to users on the stable profile.

Closes #128 
