### PR TITLE
BREAKING: remove `reader` and `writer` from `Connection`

### DIFF
--- a/connection.ts
+++ b/connection.ts
@@ -1,5 +1,6 @@
 import { readReply, sendCommand, sendCommands } from "./protocol/mod.ts";
-import type { Command, RedisReply, RedisValue } from "./protocol/mod.ts";
+import type { RedisReply, RedisValue } from "./protocol/mod.ts";
+import type { Command } from "./protocol/command.ts";
 import type { Backoff } from "./backoff.ts";
 import { exponentialBackoff } from "./backoff.ts";
 import { ErrorReplyError, isRetriableError } from "./errors.ts";
@@ -64,7 +65,7 @@ export interface RedisConnectionOptions {
 
 export const kEmptyRedisArgs: Array<RedisValue> = [];
 
-interface Command {
+interface PendingCommand {
   name: string;
   args: RedisValue[];
   promise: Deferred<RedisReply>;
@@ -84,7 +85,7 @@ export class RedisConnection implements Connection {
   private _isConnected = false;
   private backoff: Backoff;
 
-  private commandQueue: Command[] = [];
+  private commandQueue: PendingCommand[] = [];
 
   get isClosed(): boolean {
     return this._isClosed;

--- a/internal/symbols.ts
+++ b/internal/symbols.ts
@@ -1,0 +1,9 @@
+/**
+ * @private
+ */
+export const kUnstableReadReply = Symbol("deno-redis.readReply");
+
+/**
+ * @private
+ */
+export const kUnstablePipeline = Symbol("deno-redis.pipeline");

--- a/pipeline.ts
+++ b/pipeline.ts
@@ -6,7 +6,6 @@ import {
   RawOrError,
   RedisReply,
   RedisValue,
-  sendCommands,
 } from "./protocol/mod.ts";
 import { create, Redis } from "./redis.ts";
 import { kUnstablePipeline } from "./internal/symbols.ts";

--- a/pipeline.ts
+++ b/pipeline.ts
@@ -9,6 +9,7 @@ import {
   sendCommands,
 } from "./protocol/mod.ts";
 import { create, Redis } from "./redis.ts";
+import { kUnstablePipeline } from "./internal/symbols.ts";
 import {
   Deferred,
   deferred,
@@ -92,7 +93,7 @@ export class PipelineExecutor implements CommandExecutor {
   private dequeue(): void {
     const [e] = this.queue;
     if (!e) return;
-    sendCommands(this.connection.writer, this.connection.reader, e.commands)
+    this.connection[kUnstablePipeline](e.commands)
       .then(e.d.resolve)
       .catch(e.d.reject)
       .finally(() => {

--- a/pipeline.ts
+++ b/pipeline.ts
@@ -1,12 +1,7 @@
 import type { Connection, SendCommandOptions } from "./connection.ts";
 import { kEmptyRedisArgs } from "./connection.ts";
 import { CommandExecutor } from "./executor.ts";
-import {
-  okReply,
-  RawOrError,
-  RedisReply,
-  RedisValue,
-} from "./protocol/mod.ts";
+import { okReply, RawOrError, RedisReply, RedisValue } from "./protocol/mod.ts";
 import { create, Redis } from "./redis.ts";
 import { kUnstablePipeline } from "./internal/symbols.ts";
 import {

--- a/protocol/command.ts
+++ b/protocol/command.ts
@@ -98,20 +98,22 @@ export async function sendCommand(
   return readReply(reader, returnUint8Arrays);
 }
 
+export interface Command {
+  command: string;
+  args: RedisValue[];
+  returnUint8Arrays?: boolean;
+}
+
 export async function sendCommands(
   writer: BufWriter,
   reader: BufReader,
-  commands: {
-    command: string;
-    args: RedisValue[];
-    returnUint8Arrays?: boolean;
-  }[],
-): Promise<unknown[]> {
+  commands: Command[],
+): Promise<(RedisReply | ErrorReplyError)[]> {
   for (const { command, args } of commands) {
     await writeRequest(writer, command, args);
   }
   await writer.flush();
-  const ret: unknown[] = [];
+  const ret: (RedisReply | ErrorReplyError)[] = [];
   for (let i = 0; i < commands.length; i++) {
     try {
       const rep = await readReply(reader, commands[i].returnUint8Arrays);

--- a/protocol/mod.ts
+++ b/protocol/mod.ts
@@ -14,5 +14,4 @@ export type {
 
 export { okReply, readArrayReply, readReply } from "./reply.ts";
 
-export type { Command } from "./command.ts";
 export { sendCommand, sendCommands } from "./command.ts";

--- a/protocol/mod.ts
+++ b/protocol/mod.ts
@@ -14,4 +14,5 @@ export type {
 
 export { okReply, readArrayReply, readReply } from "./reply.ts";
 
+export type { Command } from "./command.ts";
 export { sendCommand, sendCommands } from "./command.ts";

--- a/pubsub.ts
+++ b/pubsub.ts
@@ -3,6 +3,7 @@ import { InvalidStateError } from "./errors.ts";
 import type { Binary } from "./protocol/mod.ts";
 import { readArrayReply } from "./protocol/mod.ts";
 import { decoder } from "./protocol/_util.ts";
+import { kUnstableReadReply } from "./internal/symbols.ts";
 
 type DefaultMessageType = string;
 type ValidMessageType = string | string[];
@@ -96,11 +97,7 @@ class RedisSubscriptionImpl<
           T,
         ];
         try {
-          // TODO: `readArrayReply` should not be called directly here
-          rep = (await readArrayReply(
-            connection.reader,
-            binaryMode,
-          )) as typeof rep;
+          rep = await connection[kUnstableReadReply](binaryMode) as typeof rep;
         } catch (err) {
           if (err instanceof Deno.errors.BadResource) {
             // Connection already closed.

--- a/pubsub.ts
+++ b/pubsub.ts
@@ -103,6 +103,10 @@ class RedisSubscriptionImpl<
             connection.close();
             break;
           }
+          if (connection.isClosed) {
+            // Connection already closed.
+            break;
+          }
           throw err;
         }
 

--- a/pubsub.ts
+++ b/pubsub.ts
@@ -1,5 +1,5 @@
 import type { CommandExecutor } from "./executor.ts";
-import { InvalidStateError } from "./errors.ts";
+import { EOFError, InvalidStateError } from "./errors.ts";
 import type { Binary } from "./protocol/mod.ts";
 import { decoder } from "./protocol/_util.ts";
 import { kUnstableReadReply } from "./internal/symbols.ts";
@@ -103,10 +103,6 @@ class RedisSubscriptionImpl<
             connection.close();
             break;
           }
-          if (connection.isClosed) {
-            // Connection already closed.
-            break;
-          }
           throw err;
         }
 
@@ -139,6 +135,7 @@ class RedisSubscriptionImpl<
         }
       } catch (error) {
         if (
+          error instanceof EOFError ||
           error instanceof InvalidStateError ||
           error instanceof Deno.errors.BadResource
         ) {

--- a/pubsub.ts
+++ b/pubsub.ts
@@ -1,7 +1,6 @@
 import type { CommandExecutor } from "./executor.ts";
 import { InvalidStateError } from "./errors.ts";
 import type { Binary } from "./protocol/mod.ts";
-import { readArrayReply } from "./protocol/mod.ts";
 import { decoder } from "./protocol/_util.ts";
 import { kUnstableReadReply } from "./internal/symbols.ts";
 


### PR DESCRIPTION
`std/io` has been deprecated in [v0.203.0](https://github.com/denoland/deno_std/releases/tag/0.203.0). This PR removes `reader` and `writer` from `Connection` to remove the dependency on `std/io`.