### PR TITLE
fix: Property 'set' does not exist on type 'Redis'.deno-ts(2339) #400

### DIFF
--- a/redis.ts
+++ b/redis.ts
@@ -19,7 +19,6 @@ import type {
   LPosWithCountOpts,
   MemoryUsageOpts,
   MigrateOpts,
-  RedisCommands,
   RestoreOpts,
   ScanOpts,
   ScriptDebugMode,
@@ -41,9 +40,9 @@ import type {
   ZScanOpts,
   ZUnionstoreOpts,
 } from "./command.ts";
-import { RedisConnection } from "./connection.ts";
 import type { Connection, SendCommandOptions } from "./connection.ts";
-import type { RedisConnectionOptions } from "./connection.ts";
+import { RedisConnection } from "./connection.ts";
+import { RedisConnectionOptions } from "./connection.ts";
 import { CommandExecutor, DefaultExecutor } from "./executor.ts";
 import type {
   Binary,
@@ -93,6 +92,8 @@ import {
   XReadOpts,
   XReadStreamRaw,
 } from "./stream.ts";
+
+import { RedisCommands } from "./command.ts";
 
 const binaryCommandOptions = {
   returnUint8Arrays: true,


### PR DESCRIPTION
This PR should fix the issue #400

```typescript
// File:: Redis.ts
// RedisCommand is currently imported as a Type. It should be imported as an Interface.
// import type { RedisCommands } from "./command.ts";
import { RedisCommands } from "./command.ts";
export interface Redis extends RedisCommands {
```