### PR TITLE
Fix auto reconnect hangup

### DIFF
--- a/tests/reconnect_test.ts
+++ b/tests/reconnect_test.ts
@@ -1,20 +1,10 @@
-import { Redis } from "../redis.ts";
 import { assertEquals } from "../vendor/https/deno.land/std/assert/mod.ts";
 import {
-  afterAll,
-  afterEach,
   beforeAll,
-  beforeEach,
   describe,
   it,
 } from "../vendor/https/deno.land/std/testing/bdd.ts";
-import {
-  newClient,
-  nextPort,
-  startRedis,
-  stopRedis,
-  TestServer,
-} from "./test_util.ts";
+import { newClient, nextPort, startRedis, stopRedis } from "./test_util.ts";
 
 describe("reconnect", () => {
   let port!: number;
@@ -39,7 +29,7 @@ describe("reconnect", () => {
     assertEquals(await client.ping(), "PONG");
     await stopRedis(server);
     server = await startRedis({ port });
-    assertEquals(await client.ping(), "PONG"); //never resolve
+    assertEquals(await client.ping(), "PONG");
     client.close();
     await stopRedis(server);
   });

--- a/tests/reconnect_test.ts
+++ b/tests/reconnect_test.ts
@@ -1,0 +1,46 @@
+import { Redis } from "../redis.ts";
+import { assertEquals } from "../vendor/https/deno.land/std/assert/mod.ts";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "../vendor/https/deno.land/std/testing/bdd.ts";
+import {
+  newClient,
+  nextPort,
+  startRedis,
+  stopRedis,
+  TestServer,
+} from "./test_util.ts";
+
+describe("reconnect", () => {
+  let port!: number;
+  beforeAll(() => {
+    port = nextPort();
+  });
+
+  it("auto reconnect", async () => {
+    let server = await startRedis({ port });
+    const client = await newClient({ hostname: "127.0.0.1", port });
+    assertEquals(await client.ping(), "PONG");
+    await stopRedis(server);
+    server = await startRedis({ port });
+    assertEquals(await client.ping(), "PONG");
+    client.close();
+    await stopRedis(server);
+  });
+
+  it("auto reconnect, with db spec", async () => {
+    let server = await startRedis({ port });
+    const client = await newClient({ hostname: "127.0.0.1", port, db: 1 });
+    assertEquals(await client.ping(), "PONG");
+    await stopRedis(server);
+    server = await startRedis({ port });
+    assertEquals(await client.ping(), "PONG"); //never resolve
+    client.close();
+    await stopRedis(server);
+  });
+});


### PR DESCRIPTION
This PR will fix the hangup problem in auto-reconnect.

I added a flag in `sendCommand` options.
The flag `inline` bypasses the queueing and executes the command immediately.

Hangup problem is avoided by executing the command `AUTH` and `SELECT` with `inline` options.

Please check:
- The fails (hangs up) if you only add the test code.
- The test passes if you apply whole changes.

Closes #430 
