### PR TITLE
fix: do not omit args if value is 0

### DIFF
--- a/redis.ts
+++ b/redis.ts
@@ -1825,7 +1825,7 @@ class RedisImpl implements Redis {
 
   xinfoStreamFull(key: string, count?: number) {
     const args = [];
-    if (count) {
+    if (count !== undefined) {
       args.push("COUNT");
       args.push(count);
     }
@@ -1941,7 +1941,7 @@ class RedisImpl implements Redis {
     count?: number,
   ) {
     const args: (string | number)[] = [key, xidstr(start), xidstr(end)];
-    if (count) {
+    if (count !== undefined) {
       args.push("COUNT");
       args.push(count);
     }
@@ -1957,7 +1957,7 @@ class RedisImpl implements Redis {
     count?: number,
   ) {
     const args: (string | number)[] = [key, xidstr(start), xidstr(end)];
-    if (count) {
+    if (count !== undefined) {
       args.push("COUNT");
       args.push(count);
     }
@@ -1972,11 +1972,11 @@ class RedisImpl implements Redis {
   ) {
     const args = [];
     if (opts) {
-      if (opts.count) {
+      if (opts.count !== undefined) {
         args.push("COUNT");
         args.push(opts.count);
       }
-      if (opts.block) {
+      if (opts.block !== undefined) {
         args.push("BLOCK");
         args.push(opts.block);
       }
@@ -2014,11 +2014,11 @@ class RedisImpl implements Redis {
       consumer,
     ];
 
-    if (count) {
+    if (count !== undefined) {
       args.push("COUNT");
       args.push(count);
     }
-    if (block) {
+    if (block !== undefined) {
       args.push("BLOCK");
       args.push(block);
     }


### PR DESCRIPTION
This PR fixes quite an obvious bug (an unexpected behavior) in case an argument passed is 0.
The `0` itself is a valid value for the affected arguments `COUNT` and, most importantly, `BLOCK`.

- `COUNT 0` should return an empty list ([source](https://redis.io/docs/latest/commands/lpos/#:~:text=LPOS%20mylist%20c-,COUNT%200,-%5B2%2C6%2C7%5D))
- `BLOCK 0` means to never timeout ([source](https://redis.io/docs/latest/develop/data-types/streams/#listening-for-new-items-with-xread:~:text=BLOCK%20option%20with%20a%20timeout%20of%200%20milliseconds%20(that%20means%20to%20never%20timeout)))

However, these arguments are currently omitted entirely when their value is 0.
This is caused by checking the argument values for being [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) that 0 is not a part of.

### Proposed changes
Explicitly check argument values for not being `undefined` (which is the only alternative value other than a `number`, according to the type definitions).
