### PR TITLE
fix: use proper xid types for xpending range

### DIFF
--- a/redis.ts
+++ b/redis.ts
@@ -1922,8 +1922,8 @@ class RedisImpl implements Redis {
     consumer?: string,
   ) {
     const args = [];
-    args.push(startEndCount.start);
-    args.push(startEndCount.end);
+    args.push(xidstr(startEndCount.start));
+    args.push(xidstr(startEndCount.end));
     args.push(startEndCount.count);
 
     if (consumer) {

--- a/stream.ts
+++ b/stream.ts
@@ -137,8 +137,8 @@ export interface XPendingCount {
  * args must be specified if _any_ are specified.
  */
 export interface StartEndCount {
-  start: number | "-";
-  end: number | "+";
+  start: XIdNeg;
+  end: XIdPos;
   count: number;
 }
 


### PR DESCRIPTION
A range that can be used in `XPENDING` is defined the same way as in `XRANGE`.

Currently, when calling `xpendingCount` the `start` and `end` arguments have `number | "-"` type, which prevents users from specifying other valid forms of `XIdInput` and indicates that the method cannot process an `XId` object.

### Proposed changes

- Update type definitions of `start` and `end` to `XIdNeg` and `XIdPos` accordingly, just like it's done for `xrange`.
- Wrap `start` and `end` arguments with `xidstr` that would transform a valid `xIdInput` to string ID.
