### PR TITLE
add self-signed root ca support for tls (fixes #469)

### DIFF
--- a/connection.ts
+++ b/connection.ts
@@ -57,6 +57,7 @@ export interface Connection {
 
 export interface RedisConnectionOptions {
   tls?: boolean;
+  caCerts?: string[];
   db?: number;
   password?: string;
   username?: string;
@@ -213,7 +214,7 @@ export class RedisConnection implements Connection {
         port: parsePortLike(this.port),
       };
       const conn: Deno.Conn = this.options?.tls
-        ? await Deno.connectTls(dialOpts)
+        ? await Deno.connectTls({ ...dialOpts, caCerts: this.options?.caCerts })
         : await Deno.connect(dialOpts);
 
       this.#conn = conn;


### PR DESCRIPTION
Just added a simple caCerts options to allow connecting to TLS enabled servers with self-signed ca. This closes #469 