### PR TITLE
add connection event listener support similar to node-redis

### DIFF
--- a/connection.ts
+++ b/connection.ts
@@ -205,7 +205,7 @@ export class RedisConnection implements Connection {
     return this.#protocol.readReply(returnsUint8Arrays);
   }
 
-  [kUnstablePipeline](commands: Array<Command>) {
+  [kUnstablePipeline](commands: Array<Command>): Promise<RedisReply[]> {
     const { promise, resolve, reject } = Promise.withResolvers<
       RedisReply[]
     >();

--- a/mod.ts
+++ b/mod.ts
@@ -58,8 +58,13 @@ export type {
 } from "./command.ts";
 export type {
   Connection,
+  ConnectionErrorEvent,
+  ConnectionEvent,
   ConnectionEventArg,
+  ConnectionEventMap,
+  ConnectionEventTarget,
   ConnectionEventType,
+  ConnectionReconnectingEvent,
   RedisConnectionOptions,
   SendCommandOptions,
 } from "./connection.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -58,6 +58,8 @@ export type {
 } from "./command.ts";
 export type {
   Connection,
+  ConnectionEventArg,
+  ConnectionEventType,
   RedisConnectionOptions,
   SendCommandOptions,
 } from "./connection.ts";

--- a/redis.ts
+++ b/redis.ts
@@ -44,7 +44,7 @@ import type {
   ZUnionstoreOpts,
 } from "./command.ts";
 import { RedisConnection } from "./connection.ts";
-import type { Connection, SendCommandOptions } from "./connection.ts";
+import type { Connection, ConnectionEventArg, ConnectionEventType, SendCommandOptions } from "./connection.ts";
 import type { RedisConnectionOptions } from "./connection.ts";
 import type { CommandExecutor } from "./executor.ts";
 import { DefaultExecutor } from "./executor.ts";
@@ -118,6 +118,9 @@ export interface Redis extends RedisCommands {
   ): Promise<RedisReply>;
   connect(): Promise<void>;
   close(): void;
+  on: typeof RedisConnection.prototype.on;
+  once: typeof RedisConnection.prototype.once;
+
   [Symbol.dispose](): void;
 }
 
@@ -154,6 +157,14 @@ class RedisImpl implements Redis {
 
   [Symbol.dispose](): void {
     return this.close();
+  }
+
+  on<T extends ConnectionEventType>(eventType: T, callback: (_: ConnectionEventArg<T>) => void) {
+    this.executor.connection.on(eventType, callback);
+  }
+
+  once<T extends ConnectionEventType>(eventType: T, callback: (_: ConnectionEventArg<T>) => void) {
+    this.executor.connection.once(eventType, callback);
   }
 
   async execReply<T extends Raw = Raw>(

--- a/redis.ts
+++ b/redis.ts
@@ -44,7 +44,12 @@ import type {
   ZUnionstoreOpts,
 } from "./command.ts";
 import { RedisConnection } from "./connection.ts";
-import type { Connection, ConnectionEventArg, ConnectionEventType, SendCommandOptions } from "./connection.ts";
+import type {
+  Connection,
+  ConnectionEventArg,
+  ConnectionEventType,
+  SendCommandOptions,
+} from "./connection.ts";
 import type { RedisConnectionOptions } from "./connection.ts";
 import type { CommandExecutor } from "./executor.ts";
 import { DefaultExecutor } from "./executor.ts";
@@ -159,11 +164,17 @@ class RedisImpl implements Redis {
     return this.close();
   }
 
-  on<T extends ConnectionEventType>(eventType: T, callback: (_: ConnectionEventArg<T>) => void) {
+  on<T extends ConnectionEventType>(
+    eventType: T,
+    callback: (_: ConnectionEventArg<T>) => void,
+  ) {
     this.executor.connection.on(eventType, callback);
   }
 
-  once<T extends ConnectionEventType>(eventType: T, callback: (_: ConnectionEventArg<T>) => void) {
+  once<T extends ConnectionEventType>(
+    eventType: T,
+    callback: (_: ConnectionEventArg<T>) => void,
+  ) {
     this.executor.connection.once(eventType, callback);
   }
 

--- a/redis.ts
+++ b/redis.ts
@@ -125,16 +125,6 @@ export interface Redis extends RedisCommands, EventTarget {
   connect(): Promise<void>;
   close(): void;
 
-  on<K extends ConnectionEventType>(
-    type: K,
-    callback: TypedEventListenerOrEventListenerObject<ConnectionEventMap[K]>,
-  ): void;
-
-  once<K extends ConnectionEventType>(
-    type: K,
-    callback: TypedEventListenerOrEventListenerObject<ConnectionEventMap[K]>,
-  ): void;
-
   [Symbol.dispose](): void;
 }
 
@@ -189,20 +179,6 @@ class RedisImpl extends (EventTarget as ConnectionEventTarget)
     const listener = callback as EventListenerOrEventListenerObject | null;
     this.executor.connection.removeEventListener(type, listener, options);
     super.removeEventListener(type, listener, options);
-  }
-
-  on<K extends ConnectionEventType>(
-    type: K,
-    callback: TypedEventListenerOrEventListenerObject<ConnectionEventMap[K]>,
-  ): void {
-    this.addEventListener(type, callback, { once: false });
-  }
-
-  once<K extends ConnectionEventType>(
-    type: K,
-    callback: TypedEventListenerOrEventListenerObject<ConnectionEventMap[K]>,
-  ): void {
-    this.addEventListener(type, callback, { once: true });
   }
 
   sendCommand(

--- a/tests/commands/connection.ts
+++ b/tests/commands/connection.ts
@@ -129,6 +129,67 @@ export function connectionTests(
 
       client.close();
     });
+
+    it("fires events", async () => {
+      const client = await connect(getOpts());
+
+      let closeEventFired = false,
+        endEventFired = false;
+
+      client.on("close", () => {
+        closeEventFired = true;
+      });
+      client.on("end", () => {
+        endEventFired = true;
+      });
+
+      client.close();
+
+      assertEquals(closeEventFired, true);
+      assertEquals(endEventFired, true);
+    });
+
+    it("fires events with a lazy client", async () => {
+      const client = createLazyClient(getOpts());
+
+      let connectEventFired = false,
+        connectEventFiredTimes = 0,
+        readyEventFired = false,
+        readyEventFiredTimes = 0,
+        closeEventFired = false,
+        endEventFired = false;
+
+      client.on("connect", () => {
+        connectEventFired = true;
+        connectEventFiredTimes++;
+      });
+      client.once("ready", () => {
+        readyEventFired = true;
+        readyEventFiredTimes++;
+      });
+      
+      client.on("close", () => {
+        closeEventFired = true;
+      });
+      client.on("end", () => {
+        endEventFired = true;
+      });
+
+      await client.exists("foo");
+      client.close();
+
+      await client.connect();
+      await client.exists("foo");
+      client.close();
+
+      assertEquals(connectEventFired, true);
+      assertEquals(readyEventFired, true);
+      assertEquals(closeEventFired, true);
+      assertEquals(endEventFired, true);
+
+      assertEquals(connectEventFiredTimes, 2);
+      assertEquals(readyEventFiredTimes, 1);
+    });
   });
 
   describe("using", () => {

--- a/tests/commands/connection.ts
+++ b/tests/commands/connection.ts
@@ -167,7 +167,7 @@ export function connectionTests(
         readyEventFired = true;
         readyEventFiredTimes++;
       });
-      
+
       client.on("close", () => {
         closeEventFired = true;
       });

--- a/tests/commands/connection.ts
+++ b/tests/commands/connection.ts
@@ -136,10 +136,10 @@ export function connectionTests(
       let closeEventFired = false,
         endEventFired = false;
 
-      client.on("close", () => {
+      client.addEventListener("close", () => {
         closeEventFired = true;
       });
-      client.on("end", () => {
+      client.addEventListener("end", () => {
         endEventFired = true;
       });
 
@@ -159,19 +159,19 @@ export function connectionTests(
         closeEventFired = false,
         endEventFired = false;
 
-      client.on("connect", () => {
+      client.addEventListener("connect", () => {
         connectEventFired = true;
         connectEventFiredTimes++;
       });
-      client.once("ready", () => {
+      client.addEventListener("ready", () => {
         readyEventFired = true;
         readyEventFiredTimes++;
-      });
+      }, { once: true });
 
-      client.on("close", () => {
+      client.addEventListener("close", () => {
         closeEventFired = true;
       });
-      client.on("end", () => {
+      client.addEventListener("end", () => {
         endEventFired = true;
       });
 

--- a/tests/commands_test.ts
+++ b/tests/commands_test.ts
@@ -41,9 +41,9 @@ describe("commands", () => {
     ]
   ) {
     describe(kind, () => {
-      //describe("acl", () => aclTests(connector, getServer));
+      describe("acl", () => aclTests(connector, getServer));
       describe("connection", () => connectionTests(connector, getServer));
-      /*describe("general", () => generalTests(connector, getServer));
+      describe("general", () => generalTests(connector, getServer));
       describe("geo", () => geoTests(connector, getServer));
       describe("hash", () => hashTests(connector, getServer));
       describe("hyperloglog", () => hyperloglogTests(connector, getServer));
@@ -55,7 +55,7 @@ describe("commands", () => {
       describe("zset", () => zsetTests(connector, getServer));
       describe("script", () => scriptTests(connector, getServer));
       describe("stream", () => streamTests(connector, getServer));
-      describe("string", () => stringTests(connector, getServer));*/
+      describe("string", () => stringTests(connector, getServer));
     });
   }
 });

--- a/tests/commands_test.ts
+++ b/tests/commands_test.ts
@@ -41,9 +41,9 @@ describe("commands", () => {
     ]
   ) {
     describe(kind, () => {
-      describe("acl", () => aclTests(connector, getServer));
+      //describe("acl", () => aclTests(connector, getServer));
       describe("connection", () => connectionTests(connector, getServer));
-      describe("general", () => generalTests(connector, getServer));
+      /*describe("general", () => generalTests(connector, getServer));
       describe("geo", () => geoTests(connector, getServer));
       describe("hash", () => hashTests(connector, getServer));
       describe("hyperloglog", () => hyperloglogTests(connector, getServer));
@@ -55,7 +55,7 @@ describe("commands", () => {
       describe("zset", () => zsetTests(connector, getServer));
       describe("script", () => scriptTests(connector, getServer));
       describe("stream", () => streamTests(connector, getServer));
-      describe("string", () => stringTests(connector, getServer));
+      describe("string", () => stringTests(connector, getServer));*/
     });
   }
 });


### PR DESCRIPTION
Tried to imitate node-redis event listener to make migrations easier. Having an event handler is always useful for logging, debugging and tracing as well.

**connect**: fires when (re)connected sucessfully
**ready**: fires when (re)connected and authenticated sucessfully, and ready to send commands
**reconnecting**: fires only before reconnection with a delay
**close**: fires after connection is closed for whatever reason
**end**: fires after connection is closed and terminated, no reconnection is planned
**error**: fires when an unexpected/uncontrolled error occurs