### PR TITLE
feat: `AbortSignal` support for `connect()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ To consume a redis cluster, you can use
 
 ## Advanced Usage
 
+### Handle connection timeout
+
+Connection timeout handling can be implemented with `signal` option:
+
+```ts
+import { connect } from "@db/redis";
+
+using redis = await connect({
+  hostname: "127.0.0.1",
+  signal: () => AbortSignal.timeout(5_000),
+});
+```
+
 ### Retriable connection
 
 By default, a client's connection will retry a command execution based on

--- a/connection.ts
+++ b/connection.ts
@@ -271,7 +271,7 @@ class RedisConnection
 
   async #connect(retryCount: number) {
     try {
-      let signal: AbortSignal | undefined = this.options?.signal?.() ??
+      const signal: AbortSignal | undefined = this.options?.signal?.() ??
         undefined;
       const dialOpts: Deno.ConnectOptions = {
         hostname: this.hostname,

--- a/tests/commands/connection.ts
+++ b/tests/commands/connection.ts
@@ -4,6 +4,7 @@ import {
   assertEquals,
   assertExists,
   assertInstanceOf,
+  assertRejects,
 } from "../../deps/std/assert.ts";
 import { afterAll, beforeAll, describe, it } from "../../deps/std/testing.ts";
 import { delay } from "../../deps/std/async.ts";
@@ -121,6 +122,17 @@ export function connectionTests(
       assertEquals(await client.ping(), "PONG");
 
       client.close();
+    });
+
+    it("supports AbortSignal", async () => {
+      const ac = new AbortController();
+      ac.abort();
+      const error = await assertRejects(async () =>
+        await connect({
+          ...getOpts(),
+          signal: () => ac.signal,
+        }), DOMException);
+      assertEquals(error.name, "AbortError");
     });
 
     it("works with a lazy client", async () => {


### PR DESCRIPTION
Closes #381