### PR TITLE
chore(internal): add `on()` helper

### DIFF
--- a/internal/on.ts
+++ b/internal/on.ts
@@ -1,0 +1,63 @@
+interface Options {
+  signal?: AbortSignal;
+}
+/**
+ * Converts {@linkcode EventTarget} to {@linkcode AsyncIterableIterator}, similar to `on()` in `node:events`.
+ */
+export function on(
+  eventTarget: EventTarget,
+  event: string,
+  options: Options = {},
+): AsyncIterableIterator<Event> {
+  // TODO: Optimize the implementation.
+  const abortController = new AbortController();
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, abortController.signal])
+    : abortController.signal;
+  const readerQueue: Array<PromiseWithResolvers<Event>> = [];
+  const bufferedEventQueue: Array<Event> = [];
+  if (!signal.aborted) {
+    eventTarget.addEventListener(
+      event,
+      (event) => {
+        if (readerQueue.length) {
+          const { resolve } = readerQueue.shift()!;
+          resolve(event);
+        } else {
+          bufferedEventQueue.push(event);
+        }
+      },
+      { signal },
+    );
+  }
+  function cleanup(): void {
+    for (const d of readerQueue) {
+      d.reject(signal.reason);
+    }
+    readerQueue.length = 0;
+  }
+  const iter: AsyncIterableIterator<Event> = {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    async next() {
+      if (signal.aborted) {
+        return { done: true, value: undefined };
+      } else if (bufferedEventQueue.length) {
+        const event = bufferedEventQueue.shift()!;
+        return { done: false, value: event };
+      } else {
+        const deferred = Promise.withResolvers<Event>();
+        readerQueue.push(deferred);
+        const value = await deferred.promise;
+        return { done: false, value };
+      }
+    },
+    return() {
+      abortController.abort();
+      cleanup();
+      return Promise.resolve({ done: true, value: undefined });
+    },
+  };
+  return iter;
+}

--- a/internal/on_test.ts
+++ b/internal/on_test.ts
@@ -1,0 +1,55 @@
+import { on } from "./on.ts";
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+} from "../deps/std/assert.ts";
+
+Deno.test({
+  name: "on",
+  permissions: "none",
+  fn: async (t) => {
+    await t.step("implements [Symbol.asyncIterator]", async () => {
+      const eventType = "foo";
+      const target = new EventTarget();
+      const ac = new AbortController();
+      const iter = on(target, eventType, { signal: ac.signal });
+      const events: Array<Event> = [];
+      const promise = (async () => {
+        for await (const event of iter) {
+          assertStrictEquals(event.type, eventType);
+          events.push(event);
+          if (events.length > 2) {
+            ac.abort();
+          }
+        }
+      })();
+      target.dispatchEvent(new CustomEvent(eventType));
+      target.dispatchEvent(new CustomEvent(eventType + "bar"));
+      target.dispatchEvent(new CustomEvent(eventType));
+      target.dispatchEvent(new CustomEvent(eventType));
+      await promise;
+      assertEquals(await iter.next(), { done: true, value: undefined });
+      assertStrictEquals(events.length, 3);
+    });
+
+    await t.step("implements Symbol.asyncIterator#return()", async () => {
+      const eventType = "bar";
+      const target = new EventTarget();
+      const ac = new AbortController();
+      const iter = on(target, eventType, { signal: ac.signal });
+
+      target.dispatchEvent(new CustomEvent(eventType));
+      const result = await iter.next();
+      assertStrictEquals(result.done, false);
+      assertStrictEquals(result.value.type, eventType);
+
+      assert(iter.return != null);
+      iter.return();
+
+      assertEquals(await iter.next(), { done: true, value: undefined });
+      target.dispatchEvent(new CustomEvent(eventType));
+      assertEquals(await iter.next(), { done: true, value: undefined });
+    });
+  },
+});


### PR DESCRIPTION
We'll use this to implement `RedisSubscription` specialized for RESP3