### PR TITLE
fix(experimental/cluster): pass connection options to individual node connections

### DIFF
--- a/deps/std/testing.ts
+++ b/deps/std/testing.ts
@@ -1,3 +1,4 @@
 export * from "jsr:@std/testing@^1/bdd";
+export * from "jsr:@std/testing@^1/mock";
 export type * from "jsr:@std/testing@^1/types";
 export { assertType } from "jsr:@std/testing@^1/types";

--- a/experimental/cluster/mod.ts
+++ b/experimental/cluster/mod.ts
@@ -26,7 +26,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { connect, create } from "../../redis.ts";
+import { connect as defaultConnect, create } from "../../redis.ts";
 import type { RedisConnectOptions } from "../../redis.ts";
 import type { Client } from "../../client.ts";
 import type {
@@ -35,7 +35,11 @@ import type {
   RedisSubscription,
   SubscribeCommand,
 } from "../../subscription.ts";
-import type { Connection, SendCommandOptions } from "../../connection.ts";
+import type {
+  Connection,
+  RedisConnectionOptions,
+  SendCommandOptions,
+} from "../../connection.ts";
 import type { Redis } from "../../redis.ts";
 import type { RedisReply, RedisValue } from "../../protocol/shared/types.ts";
 import { ErrorReplyError, NotImplementedError } from "../../errors.ts";
@@ -44,7 +48,7 @@ import { distinctBy } from "../../deps/std/collections.ts";
 import { sample, shuffle } from "../../deps/std/random.ts";
 import { calculateSlot } from "../../deps/cluster-key-slot.js";
 
-export interface ClusterConnectOptions {
+export interface ClusterConnectOptions extends RedisConnectionOptions {
   nodes: Array<NodeOptions>;
   maxConnections?: number;
   newRedis?: (opts: RedisConnectOptions) => Promise<Redis>;
@@ -93,7 +97,15 @@ class ClusterClient implements Client {
       new ClusterNode(node.hostname, node.port ?? 6379)
     );
     this.#maxConnections = opts.maxConnections ?? 50; // TODO(uki00a): To be honest, I'm not sure if this default value is appropriate...
-    this.#newRedis = opts.newRedis ?? connect;
+    const connect = opts.newRedis ?? defaultConnect;
+    const {
+      nodes: _nodes,
+      maxConnections: _maxConnections,
+      newRedis: _newRedis,
+      ...sharedConnectOptions
+    } = opts;
+    this.#newRedis = (connectOptions: RedisConnectOptions) =>
+      connect({ ...sharedConnectOptions, ...connectOptions });
   }
 
   get connection(): Connection {

--- a/tests/cluster/test.ts
+++ b/tests/cluster/test.ts
@@ -14,6 +14,7 @@ import {
   beforeAll,
   describe,
   it,
+  spy,
 } from "../../deps/std/testing.ts";
 import { calculateSlot } from "../../deps/cluster-key-slot.js";
 import { ErrorReplyError } from "../../errors.ts";
@@ -41,6 +42,47 @@ describe("experimental/cluster", () => {
   afterAll(() => stopRedisCluster(cluster));
 
   afterEach(() => client.close());
+
+  it("correctly passes ConnectionOptions to newRedis", async () => {
+    {
+      const newRedis = spy(connect);
+      const clientWithOptions = await connectToCluster({
+        newRedis,
+        nodes,
+      });
+      assertEquals(
+        newRedis.calls.at(-1)?.args[0].noDelay,
+        undefined,
+        "should not pass `noDelay` option if absent (shared RedisConnectionOption)",
+      );
+      assertEquals(
+        (newRedis.calls.at(-1)?.args[0] as any).nodes,
+        undefined,
+        "should never pass `nodes` option (exclusive of ClusterConnectionOption)",
+      );
+      clientWithOptions.close();
+    }
+
+    {
+      const newRedis = spy(connect);
+      const clientWithOptions = await connectToCluster({
+        newRedis,
+        nodes,
+        noDelay: true,
+      });
+      assertEquals(
+        newRedis.calls.at(-1)?.args[0].noDelay,
+        true,
+        "should pass `noDelay` option if present (shared RedisConnectionOption)",
+      );
+      assertEquals(
+        (newRedis.calls.at(-1)?.args[0] as any).nodes,
+        undefined,
+        "should never pass `nodes` option (exclusive of ClusterConnectionOption)",
+      );
+      clientWithOptions.close();
+    }
+  });
 
   it("del multiple keys in the same hash slot", async () => {
     await client.set("{hoge}foo", "a");

--- a/tests/cluster/test.ts
+++ b/tests/cluster/test.ts
@@ -1,5 +1,6 @@
 import { nextPorts, startRedisCluster, stopRedisCluster } from "./test_util.ts";
 import type { TestCluster } from "./test_util.ts";
+import type { ClusterConnectOptions } from "../../experimental/cluster/mod.ts";
 import { connect as connectToCluster } from "../../experimental/cluster/mod.ts";
 import {
   assert,
@@ -19,8 +20,9 @@ import {
 import { calculateSlot } from "../../deps/cluster-key-slot.js";
 import { ErrorReplyError } from "../../errors.ts";
 import { connect, create } from "../../redis.ts";
+import type { RedisConnectOptions } from "../../redis.ts";
 import type { CommandExecutor } from "../../executor.ts";
-import type { Connection } from "../../connection.ts";
+import type { Connection, RedisConnectionOptions } from "../../connection.ts";
 import type { Redis } from "../../mod.ts";
 
 describe("experimental/cluster", () => {
@@ -43,9 +45,17 @@ describe("experimental/cluster", () => {
 
   afterEach(() => client.close());
 
-  it("correctly passes ConnectionOptions to newRedis", async () => {
+  it("correctly passes connection options to newRedis", async () => {
     {
-      const newRedis = spy(connect);
+      const newRedis = spy<
+        unknown,
+        [
+          options:
+            & RedisConnectOptions
+            & Partial<ClusterConnectOptions & RedisConnectionOptions>,
+        ],
+        Promise<Redis>
+      >(connect);
       const clientWithOptions = await connectToCluster({
         newRedis,
         nodes,
@@ -53,18 +63,26 @@ describe("experimental/cluster", () => {
       assertEquals(
         newRedis.calls.at(-1)?.args[0].noDelay,
         undefined,
-        "should not pass `noDelay` option if absent (shared RedisConnectionOption)",
+        "should not pass `noDelay` option if absent (shared RedisConnectionOptions)",
       );
       assertEquals(
-        (newRedis.calls.at(-1)?.args[0] as any).nodes,
+        newRedis.calls.at(-1)?.args[0].nodes,
         undefined,
-        "should never pass `nodes` option (exclusive of ClusterConnectionOption)",
+        "should never pass `nodes` option (exclusive of ClusterConnectOptions)",
       );
       clientWithOptions.close();
     }
 
     {
-      const newRedis = spy(connect);
+      const newRedis = spy<
+        unknown,
+        [
+          options:
+            & RedisConnectOptions
+            & Partial<ClusterConnectOptions & RedisConnectionOptions>,
+        ],
+        Promise<Redis>
+      >(connect);
       const clientWithOptions = await connectToCluster({
         newRedis,
         nodes,
@@ -73,12 +91,12 @@ describe("experimental/cluster", () => {
       assertEquals(
         newRedis.calls.at(-1)?.args[0].noDelay,
         true,
-        "should pass `noDelay` option if present (shared RedisConnectionOption)",
+        "should pass `noDelay` option if present (shared RedisConnectionOptions)",
       );
       assertEquals(
-        (newRedis.calls.at(-1)?.args[0] as any).nodes,
+        newRedis.calls.at(-1)?.args[0].nodes,
         undefined,
-        "should never pass `nodes` option (exclusive of ClusterConnectionOption)",
+        "should never pass `nodes` option (exclusive of ClusterConnectOptions)",
       );
       clientWithOptions.close();
     }


### PR DESCRIPTION
Before this change, connection options like 'tls', 'username', and 'password' were not applied to individual Redis node connections in cluster mode.

When running Redis in Cluster mode with TLS and user/password authentication enabled, every individual connection to every single node must use TLS and perform authentication. Now ClusterConnectOptions extends RedisConnectionOptions, allowing these shared options to be passed through to each node connection.