### PR TITLE
fix: preserve empty-string field names in stream parsing

### DIFF
--- a/stream.ts
+++ b/stream.ts
@@ -221,7 +221,7 @@ export function parseXMessage(raw: XReadIdData): XMessage {
   for (const data of raw[1]) {
     if (m % 2 === 0) {
       f = data;
-    } else if (f) {
+    } else if (f !== undefined) {
       fieldValues[f] = data;
     }
     m++;
@@ -238,7 +238,7 @@ export function convertMap(raw: ConditionalArray): Map<string, Raw> {
   for (const data of raw) {
     if (m % 2 === 0 && typeof data === "string") {
       f = data;
-    } else if (m % 2 === 1 && f) {
+    } else if (m % 2 === 1 && f !== undefined) {
       fieldValues.set(f, data);
     }
     m++;

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -1,0 +1,32 @@
+import { convertMap, parseXMessage } from "../stream.ts";
+import { assertEquals } from "../deps/std/assert.ts";
+import { describe, it } from "../deps/std/testing.ts";
+
+describe("stream", {
+  permissions: "none",
+}, () => {
+  describe("parseXMessage", () => {
+    it("preserves empty-string field names", () => {
+      const result = parseXMessage(["1-0", ["", "value"]]);
+      assertEquals(result.fieldValues, { "": "value" });
+    });
+
+    it("parses non-empty field/value pairs", () => {
+      const result = parseXMessage(["1-0", ["foo", "bar", "baz", "qux"]]);
+      assertEquals(result.fieldValues, { foo: "bar", baz: "qux" });
+    });
+  });
+
+  describe("convertMap", () => {
+    it("preserves empty-string field names", () => {
+      const result = convertMap(["", "value"]);
+      assertEquals(result.get(""), "value");
+    });
+
+    it("parses non-empty field/value pairs", () => {
+      const result = convertMap(["foo", "bar", "baz", "qux"]);
+      assertEquals(result.get("foo"), "bar");
+      assertEquals(result.get("baz"), "qux");
+    });
+  });
+});


### PR DESCRIPTION
`parseXMessage` and `convertMap` use `if (f)` to gate the value assignment, which skips entries whose field name is the empty string (a valid field name in Redis streams). Switching the guard to `f !== undefined` keeps those entries in the parsed result.

Closes #363